### PR TITLE
Put provider in search result and course detail title

### DIFF
--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -16,6 +16,10 @@
         </h1>
         <div class="course-basicinfo">
             <dl role="contentinfo">
+                @if (Model.Course.ProviderLocation != null) {
+                    <dt>Location</dt>
+                    <dd>@Model.Course.ProviderLocation.Address</dd>
+                }
                 <dt>Qualification</dt>
                 <dd>
                     @if (Model.Course.IncludesPgce != IncludesPgce.No) {

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -11,9 +11,9 @@
 
 <div class="grid-row">
     <div class="column-full">
-        <h2 class="heading-large" role="heading">
-            @Model.Course.Name
-        </h2>
+        <h1 class="heading-xlarge" role="heading">
+            @Model.Course.Name at @Model.Provider.Name
+        </h1>
         <div class="course-basicinfo">
             <dl role="contentinfo">
                 <dt>Qualification</dt>
@@ -39,9 +39,6 @@
                     </details>
                     }
                 </dd>
-
-                <dt>Training provider</dt>
-                <dd>@Model.Provider.Name</dd>
 
                 <dt>Financial support</dt>
                 <dd>@Model.Course.FundingOptions()</dd>
@@ -75,9 +72,9 @@
                 @if (Model.HasSection("about placement schools")) {
                     <li><a href="#section-schools">Placement schools</a></li>
                 }
-                
+
                 <li><a href="#section-fees">Fees and funding</a></li>
-                
+
                 @if (Model.HasSection("about this training provider")) {
                 <li><a href="#section-about-provider">About the training provider</a></li>
                 }
@@ -85,7 +82,7 @@
                 @if (Model.HasContactDetails()) {
                 <li><a href="#section-contact">Contact details</a></li>
                 }
-                
+
                 <li><a href="#section-apply">Apply</a></li>
             </ul>
         </div>
@@ -114,7 +111,7 @@
             </div>
         }
 
-        @if (Model.HasSection("about placement schools")) {        
+        @if (Model.HasSection("about placement schools")) {
             <div class="course-details-section">
                 <a name="section-schools"></a>
                 <h3 class="heading-medium">
@@ -130,11 +127,11 @@
                     </p>
                     <table class="alt">
                         <tr>
-                            <th>Name</th>                    
-                            <th>Address</th>                    
-                            <th>Code</th>                    
-                            <th>Vacancies</th>                    
-                            <th>Study type</th>                    
+                            <th>Name</th>
+                            <th>Address</th>
+                            <th>Code</th>
+                            <th>Vacancies</th>
+                            <th>Study type</th>
                         </tr>
                         @foreach(var campus in Model.Course.Campuses) {
                             <tr>
@@ -199,7 +196,7 @@
             </div>
         </div>
 
-        @if (Model.HasSection("about this training provider")) {        
+        @if (Model.HasSection("about this training provider")) {
             <div class="course-details-section">
                 <a name="section-about-provider"></a>
                 <h3 class="heading-medium">
@@ -210,7 +207,7 @@
                 </div>
             </div>
         }
-        
+
         @if (Model.HasContactDetails()) {
             <div class="course-details-section">
                 <a name="section-contact"></a>
@@ -257,7 +254,7 @@
             </div>
         }
 
-        
+
         <div class="course-details-section">
             <a name="section-apply"></a>
             <h3 class="heading-medium">

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -13,17 +13,13 @@
     var subjects = @item.CourseSubjects.Select(courseSubject => courseSubject.Subject.Name).ToArray();
     <li class="bat_searchresult" role="listitem">
         <h3 class="heading-medium">
-            <a href='@Url.Action("Index", "Course", RoutingUtil.Combine(Model.FilterModel.ToRouteValues(), new {courseId = item.Id}))' class="link">@item.Name</a>
+            <a href='@Url.Action("Index", "Course", RoutingUtil.Combine(Model.FilterModel.ToRouteValues(), new {courseId = item.Id}))' class="link">@item.Name at @item.Provider.Name</a>
         </h3>
-        <dl>                
-            <dt>Training provider</dt>
-            <dd>@item.Provider.Name</dd>
-            
+        <dl>
             @if (item.ProviderLocation != null) {
                 <dt>Training provider&apos;s location</dt>
                 <dd>@item.ProviderLocation.Address</dd>
             }
-
             <dt>Study type</dt>
             <dd>@item.FormattedStudyInfo()</dd>
 

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -17,7 +17,7 @@
         </h3>
         <dl>
             @if (item.ProviderLocation != null) {
-                <dt>Training provider&apos;s location</dt>
+                <dt>Location</dt>
                 <dd>@item.ProviderLocation.Address</dd>
             }
             <dt>Study type</dt>


### PR DESCRIPTION
In the private beta all subjects will be business studies. Subject alone is not distinguishing enough as a title.

* Make search result and detail page include provider in title
* Rename "training provider location" to "location"
* Add location to course detail page

Paired with Ray Khan on the copy.

## Before
![screen shot 2018-04-23 at 12 16 52](https://user-images.githubusercontent.com/319055/39123665-6d10104c-46f0-11e8-8c6d-02f819e1c98b.png)

## After
![screen shot 2018-04-23 at 12 17 39](https://user-images.githubusercontent.com/319055/39123666-6d25d508-46f0-11e8-93fb-d1c08970d32a.png)

