### PR TITLE
Minor semantics, spacing and stylistic tweaks

### DIFF
--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -155,20 +155,22 @@
             <div>
                 <h4 class="heading-small">Fees</h4>
                 <p>The course fees for @Model.Finance.FormattedYear are as follows:</p>
-                <table>
-                    <tr class="visually-hidden">
-                        <th>Student type</th><th>Fees to pay</th>
-                    </tr>
-                    <tr>
-                        <td>UK students</td><td>@Model.Finance.FormattedUkFees</td>
-                    </tr>
-                    <tr>
-                        <td>EU students</td><td>@Model.Finance.FormattedEuFees</td>
-                    </tr>
-                    <tr>
-                        <td>International students</td><td>@Model.Finance.FormattedInternationalFees</td>
-                    </tr>
-                </table>
+                <div class="body-text">
+                  <table>
+                      <tr class="visually-hidden">
+                          <th>Student type</th><th>Fees to pay</th>
+                      </tr>
+                      <tr>
+                          <td>UK students</td><td>@Model.Finance.FormattedUkFees</td>
+                      </tr>
+                      <tr>
+                          <td>EU students</td><td>@Model.Finance.FormattedEuFees</td>
+                      </tr>
+                      <tr>
+                          <td>International students</td><td>@Model.Finance.FormattedInternationalFees</td>
+                      </tr>
+                  </table>
+                </div>
 
                 @if (Model.Finance.IsSalaried) {
                     <h4 class="heading-small">Funding</h4>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -92,8 +92,7 @@
 
         @if (Model.HasSection("about this training programme")) {
             <div class="course-details-section">
-                <a name="section-about"></a>
-                <h3 class="heading-medium">
+                <h3 class="heading-medium" id="section-about">
                     About the course
                 </h3>
                 <div>
@@ -104,8 +103,7 @@
 
         @if (Model.HasSection("entry requirements")) {
             <div class="course-details-section">
-                <a name="section-entry"></a>
-                <h3 class="heading-medium">
+                <h3 class="heading-medium" id="section-entry">
                     Requirements
                 </h3>
                 <div>
@@ -116,8 +114,7 @@
 
         @if (Model.HasSection("about placement schools")) {        
             <div class="course-details-section">
-                <a name="section-schools"></a>
-                <h3 class="heading-medium">
+                <h3 class="heading-medium" id="section-schools">
                     Placement schools
                 </h3>
                 <div>
@@ -152,8 +149,7 @@
         }
 
         <div class="course-details-section">
-            <a name="section-fees"></a>
-            <h3 class="heading-medium">
+            <h3 class="heading-medium" id="section-fees">
                 Fees and funding
             </h3>
             <div>
@@ -201,8 +197,7 @@
 
         @if (Model.HasSection("about this training provider")) {        
             <div class="course-details-section">
-                <a name="section-about-provider"></a>
-                <h3 class="heading-medium">
+                <h3 class="heading-medium" id="section-about-provider">
                     About the training provider
                 </h3>
                 <div>
@@ -213,8 +208,7 @@
         
         @if (Model.HasContactDetails()) {
             <div class="course-details-section">
-                <a name="section-contact"></a>
-                <h3 class="heading-medium">
+                <h3 class="heading-medium" id="section-contact">
                     Contact details
                 </h3>
                 <div class="course-basicinfo">
@@ -259,8 +253,7 @@
 
         
         <div class="course-details-section">
-            <a name="section-apply"></a>
-            <h3 class="heading-medium">
+            <h3 class="heading-medium" id="section-apply">
                 Apply
             </h3>
             <div>

--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -27,23 +27,22 @@
                 <legend role="heading">
                     <h1 class="heading-xlarge">Financial support while you&nbsp;train</h1>
                 </legend>
-                <div>
+                <p>
                     Some courses come with financial support to help you with the cost of teacher training.
-                </div>
+                </p>
 
                 <div class="form-group @(errors.HasError("applyFilter") ? "form-group-error" : "")" id="applyFilter-container">
                     <div class="multiple-choice multiple-radio">
                         <input id="applyFilter-all" type="radio" name="applyFilter" value="false" checked="@(Model.SelectedFunding == FundingOption.All)">
                         <label for="applyFilter-all" class="multi-choice-label">
-                            <span class="bold">Show courses with and without financial support</span>
+                            Show courses with and without financial support
                         </label>
                     </div>
 
                     <div class="multiple-choice multiple-radio" data-target="funding-container">
                         <input id="applyFilter-some" type="radio" name="applyFilter" value="true" checked="@(errors.HasError("funding") || (Model.SelectedFunding != null && Model.SelectedFunding != FundingOption.All))">
                         <label for="applyFilter-some" class="multi-choice-label">
-                            <span class="bold">Only show me courses that come with financial support</span>
-
+                            Only show me courses that come with financial support
                         </label>
                     </div>
                     <div class="panel panel-border-narrow js-hidden @(errors.HasError("funding") ? "form-group-error" : "")" id="funding-container">

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -36,19 +36,22 @@
                         </label>
                     </div>
                     <div class="panel panel-border-narrow js-hidden @(Model.Errors.HasError("lq") ? "form-group-error" : "")" id="lq-container">
-                        <label class="form-label" for="location">
-                            Postcode, town or city
-                            <span class="error-message">@Model.Errors.GetError("lq").Message</span>
-                        </label>
-                        <input class="form-control typeahead" data-url="@Url.Action("LocationSuggest", "Dynamic")" name="lq" type="text" id="location" value="@Model.FilterModel.lq">
-
-                        <label class="form-label" for="radius">Within Radius</label>
-                        <select class="form-control" id="radius" name="rad">
-                            @foreach(var option in Enum.GetValues(typeof(RadiusOption)))
-                            {
-                                <option value="@((int) option)">@((int) option) miles</option>
-                            }
-                        </select>
+                        <div class="form-group">
+                            <label class="form-label" for="location">
+                                Postcode, town or city
+                                <span class="error-message">@Model.Errors.GetError("lq").Message</span>
+                            </label>
+                            <input class="form-control typeahead" data-url="@Url.Action("LocationSuggest", "Dynamic")" name="lq" type="text" id="location" value="@Model.FilterModel.lq">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="radius">Within Radius</label>
+                            <select class="form-control" id="radius" name="rad">
+                                @foreach(var option in Enum.GetValues(typeof(RadiusOption)))
+                                {
+                                    <option value="@((int) option)">@((int) option) miles</option>
+                                }
+                            </select>
+                        </div>
                     </div>
 
                     <div class="multiple-choice multiple-radio">

--- a/src/Views/Home/Index_privatebeta.cshtml
+++ b/src/Views/Home/Index_privatebeta.cshtml
@@ -1,7 +1,6 @@
 <div class="grid-row">
     <div class="column-two-thirds">
         <h1 class="heading-xlarge" role="heading">
-            <span class="heading-secondary">GOV.UK</span>
             Find postgraduate teacher training for business studies
         </h1>
         <p class="lede">

--- a/src/Views/Shared/Back.cshtml
+++ b/src/Views/Shared/Back.cshtml
@@ -1,10 +1,2 @@
 @model BackLinkViewModel
-
-<div class="grid-row">
-    <div class="column-full">
-        <h3 class="heading-small back-link">
-        <a href='@Model.Href'
-            class="link-back back-link">@Model.Title</a>
-        </h3>
-    </div>
-</div>
+<a href='@Model.Href' class="link-back">@Model.Title</a>

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -232,15 +232,6 @@ table.alt th
     }
 }
 
-
-h3.back-link {
-    margin-top: 5px;
-}
-a.back-link {
-    margin-top: 8px;
-    margin-bottom: 8px;
-}
-
 .course-details-section {
     float: left;
     width: 100%;


### PR DESCRIPTION
See individual commits for detail.

## Fix spacing between location and radius

| Before | After |
|-|-|
|![screen shot 2018-04-24 at 14 31 00](https://user-images.githubusercontent.com/319055/39190305-3935c88e-47cc-11e8-9a06-f4935721acec.png)|![screen shot 2018-04-24 at 14 31 36](https://user-images.githubusercontent.com/319055/39190306-3954ba8c-47cc-11e8-93e6-e4a45483488c.png)|

## Fix back link spacing and `bold` labels

| Before | After |
|-|-|
|![screen shot 2018-04-24 at 14 32 26](https://user-images.githubusercontent.com/319055/39190373-6101baf8-47cc-11e8-961a-7fae0631f106.png)| ![screen shot 2018-04-24 at 14 32 40](https://user-images.githubusercontent.com/319055/39190374-61208a8c-47cc-11e8-884e-29786d7fbf94.png)|

## Fix funding link spacing

| Before | After |
|-|-|
|![screen shot 2018-04-24 at 14 34 35](https://user-images.githubusercontent.com/319055/39190539-b6b01972-47cc-11e8-957f-f1ca1c0de5a6.png)|![screen shot 2018-04-24 at 14 35 03](https://user-images.githubusercontent.com/319055/39190540-b6cf62f0-47cc-11e8-95b7-840066ba6f02.png)|
