### PR TITLE
Update finance options and start page

### DIFF
--- a/src/Filters/ResultsFilter.cs
+++ b/src/Filters/ResultsFilter.cs
@@ -310,7 +310,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         {
             if (SelectedFunding == null || SelectedFunding == FundingOption.All)
             {
-                yield return "With and without salaries";
+                yield return "Student finance and salaries";
                 yield break;
             }
 

--- a/src/ViewFormatters/CourseExtensions.cs
+++ b/src/ViewFormatters/CourseExtensions.cs
@@ -100,7 +100,7 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewFormatters
             }
             else
             {
-                return "None";
+                return "Student finance if you’re eligible";
             }
         }
 

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -186,20 +186,15 @@
                             <li>@Model.Finance.FormattedMaxBursary</li>
                         }
                     </ul>
+                } else {
+                  <p>
+                      You may be eligible for <a href="https://www.gov.uk/student-finance">financial support for students</a>.
+                  </p>
                 }
 
                 <p>
-                    Find out more about:
+                    <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">Financial support if you’re from outside of the UK</a>
                 </p>
-                <ul class="list list-bullet">
-                    <li>
-                      <a href="https://www.gov.uk/student-finance">financial support for students</a>
-                    </li>
-                    <li>
-                      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">financial support if you’re from outside of the UK</a>
-                    </li>
-                </ul>
-
             </div>
         </div>
 

--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -28,21 +28,21 @@
                     <h1 class="heading-xlarge">Financial support while you&nbsp;train</h1>
                 </legend>
                 <p>
-                    Some business studies teacher training courses offer you a salary.
+                    Business studies courses come with either student finance (a tuition fee loan and maintenance loan, if you’re eligible) or a salary.
                 </p>
 
                 <div class="form-group @(errors.HasError("applyFilter") ? "form-group-error" : "")" id="applyFilter-container">
                     <div class="multiple-choice multiple-radio">
                         <input id="applyFilter-all" type="radio" name="applyFilter" value="false" checked="@(Model.SelectedFunding == FundingOption.All)">
                         <label for="applyFilter-all" class="multi-choice-label">
-                            Show courses with and without a salary
+                            All courses (with salaries or with student finance)
                         </label>
                     </div>
 
                     <div class="multiple-choice multiple-radio">
                         <input id="applyFilter-some" type="radio" name="applyFilter" value="true" checked="@(errors.HasError("funding") || (Model.SelectedFunding != null && Model.SelectedFunding != FundingOption.All))">
                         <label for="applyFilter-some" class="multi-choice-label">
-                            Only show courses that come with a salary
+                            Only courses that come with a salary
                         </label>
                     </div>
 
@@ -51,6 +51,8 @@
                     <input type="hidden" name="includeSalary" value="true">
                 </div>
             </fieldset>
+
+            <p>You can <a href="https://www.gov.uk/student-finance">find out more about student finance and the eligibility requirements</a>.</p>
 
             <div class="filter-apply-button">
                 <input class="button" type="submit" value="Find courses">
@@ -61,9 +63,6 @@
             </h2>
             <p>
                 Some other subjects offer different types of financial support for trainee teachers. You can find out more about <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject">financial support for trainee teachers</a> on the Get into Teaching website.
-            </p>
-            <p>
-                You may also be eligible for <a href="https://www.gov.uk/student-finance">financial support for students</a>.
             </p>
         </form>
     </div>

--- a/src/Views/Home/Index_privatebeta.cshtml
+++ b/src/Views/Home/Index_privatebeta.cshtml
@@ -11,22 +11,29 @@
            class="button button-start" role="button">Start now</a>
 
         <h2 class="heading-medium">
-            Qualifications you’ll need
+            What you’ll need
         </h2>
-        <p>
-            To get onto a training course you’ll need the following qualifications or the international equivalent:
-        </p>
+
+        <h3 class="heading-small">GCSEs</h3>
+
+        <p>To apply for a course you’ll need grade 4 (previously grade C) GCSEs in maths and English.</p>
+
+        <p>If you want to teach in a primary school you’ll also need a minimum grade 4 in a science subject.</p>
+
+        <p>If you don’t have these qualifications, you must prove you have the equivalent level of knowledge in these subjects.</p>
+
+        <h3 class="heading-small">Degree</h3>
+
+        <p>You’ll need a UK degree, or the international equivalent.</p>
+
+        <h3 class="heading-small">Tests and checks</h3>
+
+        <p>Before you start the course you’ll need to:</p>
+
         <ul class="list list-bullet">
-            <li>
-                grade C or above GCSEs in maths and English, plus a science subject if you want to teach in a primary school
-            </li>
-            <li>
-                a British degree
-            </li>
+            <li>pass literacy and numeracy skills tests</li>
+            <li>have a Disclosure and Barring Service (DBS) security check</li>
         </ul>
-        <p>
-            If English isn’t your first language you’ll need to pass the <a href="https://www.ielts.org" rel="external">IELTS exam</a> with a score of 6.5 or higher, or an equivalent qualification.
-        </p>
 
         <h2 class="heading-medium">
             If you don&#8217;t want to teach business&nbsp;studies
@@ -48,20 +55,10 @@
               if you <a href="https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/university-led-training/university-led-undergraduate-training">don’t have a degree</a>
             </li>
             <li>
-              if you <a href="https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/specialist-training-options/assessment-only">have a degree and have already taught in 2 or more schools</a>&nbsp;–&nbsp;you might not need to do any more training
+              if you <a href="https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/specialist-training-options/assessment-only">have a degree and teaching experience already</a>&nbsp;–&nbsp;you might not need to do any more training
             </li>
             <li>
-              <a href="https://getintoteaching.education.gov.uk/explore-my-options/become-an-early-years-teacher">Early Years</a>
-            </li>
-        </ul>
-
-        <p>You could also earn a salary while you train through:</p>
-        <ul class="list list-bullet">
-            <li>
-              <a href="https://www.teachfirst.org.uk">Teach First</a>
-            </li>
-            <li>
-              <a href="http://www.researchersinschools.org">Researchers in Schools</a>, if you have a PhD
+              <a href="https://www.teachfirst.org.uk/">young people from poorer backgrounds</a>, through Teach First
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Update finance options to include student finance. "Financial options: None" gave the wrong impression. There are finance options in the form of student loans, etc.

Clarify the start page:
* Make GCSE requirements clearer
* Remove other ways into teaching which aren't relevant for business studies
* Make tests and checks clearer

https://dfedigital.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=BATSA&modal=detail&selectedIssue=BATSA-247