### PR TITLE
Added Cookies, Privacy Policy and, Terms and Condition pages

### DIFF
--- a/src/Controllers/LegalController.cs
+++ b/src/Controllers/LegalController.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using GovUk.Education.SearchAndCompare.UI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using GovUk.Education.SearchAndCompare.UI.ActionFilters;
+
+namespace GovUk.Education.SearchAndCompare.UI.Controllers
+{
+    public class LegalController : CommonAttributesControllerBase
+    {
+        [HttpGet("cookies")]
+        public IActionResult Cookies()
+        {
+            return View();
+        }
+    }
+}

--- a/src/Controllers/LegalController.cs
+++ b/src/Controllers/LegalController.cs
@@ -14,5 +14,17 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             return View();
         }
+
+        [HttpGet("privacy-policy")]
+        public IActionResult Privacy()
+        {
+            return View();
+        }
+
+        [HttpGet("terms-conditions")]
+        public IActionResult TandC()
+        {
+            return View();
+        }
     }
 }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -68,6 +68,10 @@ namespace GovUk.Education.SearchAndCompare.UI
             app.UseMvc(routes => {
                 routes.MapRoute("cookies", "cookies",
                     defaults: new { controller = "Legal", action = "Cookies" });
+                routes.MapRoute("privacy", "privacy-policy",
+                    defaults: new { controller = "Legal", action = "Privacy" });
+                routes.MapRoute("tandc", "terms-conditions",
+                    defaults: new { controller = "Legal", action = "TandC" });
             });
         }
     }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -65,7 +65,10 @@ namespace GovUk.Education.SearchAndCompare.UI
 
             app.AddContentLanguageHeaders("en");
 
-            app.UseMvc(routes => {});
+            app.UseMvc(routes => {
+                routes.MapRoute("cookies", "cookies",
+                    defaults: new { controller = "Legal", action = "Cookies" });
+            });
         }
     }
 }

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -1,14 +1,116 @@
+ @{ ViewBag.Title = $"Cookies"; }
 
-@{
-    ViewBag.Title = $"Cookies page ";
-}
+<article class="text" id="content">
+    <h1 class="heading-xlarge">Cookies</h1>
 
+    <div class="grid">
+        <div class="column-two-thirds">
+            <p>Find postgraduate teacher training puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
 
+            <p class="heading-medium">Cookies are used to</p>
+            <ul class="list-bullet">
+                <li>measure how you use the website so it can be updated and improved based on your needs</li>
+                <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+                <li>remember who you are when you have logged in so we can show you your information and information relevant to you</li>
+            </ul>
 
-<div class="grid-row">
-    <div class="column-two-thirds">
-        <h1 class="heading-large" role="heading">
-            Cookies
-        </h1>
+            <p>Find postgraduate teacher training cookies aren’t used to identify you personally.</p>
+            <p>Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.</p>
+
+            <p class="heading-medium">How we use cookies</p>
+            <p class="heading-small">Measuring website usage (Google Analytics)</p>
+            <p>We use Google Analytics software to collect information about how you use Find postgraduate teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
+
+            <p class="heading-medium">Google Analytics stores information about:</p>
+
+            <ul class="list-bullet">
+                <li>the pages you visit on Find postgraduate teacher training</li>
+                <li>how long you spend on each page</li>
+                <li>how you got to the site</li>
+                <li>what you click on while you’re visiting the site</li>
+            </ul>
+
+            <div class="panel-indent">
+                <p>We don’t allow Google to use or share our analytics data.</p>
+            </div>
+
+            <p class="heading-medium">Google Analytics sets the following cookies:</p>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Purpose</th>
+                        <th>Expires</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>_ga</td>
+                        <td>Used to distinguish anonymous users</td>
+                        <td>2 years</td>
+                    </tr>
+                    <tr>
+                        <td>_gid</td>
+                        <td>Used to distinguish anonymous users</td>
+                        <td>24 hours</td>
+                    </tr>
+                    <tr>
+                        <td>_gat_gtag_UA_112932657_1</td>
+                        <td>Used to distinguish anonymous users</td>
+                        <td>10 minutes</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external">Google Analytics</a>.</p>
+
+            <p class="heading-medium">Our introductory message</p>
+
+            <p>You may see a pop-up welcome message when you first visit Find postgraduate teacher training. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+            <table>
+
+                <thead>
+                    <tr>
+
+                        <th>Name</th>
+                        <th>Purpose</th>
+                        <th>Expires</th>
+
+                    </tr>
+                </thead>
+
+                <tbody>
+                    <tr>
+                        <td>seen_cookie_message</td>
+                        <td>Show cookie policy banner on first visit only</td>
+                        <td>1 month</td>
+
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>Other Find postgraduate teacher training cookies may include:</p>
+            <table>
+                <thead>
+                    <tr>
+
+                        <th>Name</th>
+                        <th>Purpose</th>
+                        <th>Expires</th>
+
+                    </tr>
+                </thead>
+
+                <tbody>
+                    <tr>
+                        <td>b90b2935d687fb546d80508b818e20d3</td>
+                        <td>Load balancing</td>
+                        <td>never</td>
+
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
+</article>

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -20,7 +20,7 @@
 
         <h3 class="heading-medium">Measuring website usage (Google Analytics)</h3>
 
-        <p>We use Google Analytics software to collect information about how you use Find postgraduate teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
+        <p>We use Google Analytics software to collect information about how you use ‘Find postgraduate teacher training’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
 
         <p>Google Analytics stores information about:</p>
         <ul class="list list-bullet">
@@ -88,7 +88,7 @@
             </table>
         </div>
 
-        <p>Other Find postgraduate teacher training cookies may include:</p>
+        <p>Other ‘Find postgraduate teacher training’ cookies may include:</p>
         <div class="body-text">
             <table>
                 <thead>

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -4,16 +4,16 @@
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <p>Find postgraduate teacher training puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
+        <p>‘Find postgraduate teacher training’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
 
         <p>Cookies are used to:</p>
         <ul class="list list-bullet">
-            <li>measure how you use the website so it can be updated and improved based on your needs</li>
+            <li>measure how you use the this service so it can be updated and improved based on your needs</li>
             <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
             <li>remember who you are when you have logged in so we can show you your information and information relevant to you</li>
         </ul>
 
-        <p>Find postgraduate teacher training cookies aren’t used to identify you personally.</p>
+        <p>‘Find postgraduate teacher training’ cookies aren’t used to identify you personally.</p>
         <p>Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.</p>
 
         <h2 class="heading-large">How we use cookies</h2>
@@ -24,7 +24,7 @@
 
         <p>Google Analytics stores information about:</p>
         <ul class="list list-bullet">
-            <li>the pages you visit on Find postgraduate teacher training</li>
+            <li>the pages you visit on ‘Find postgraduate teacher training’</li>
             <li>how long you spend on each page</li>
             <li>how you got to the site</li>
             <li>what you click on while you’re visiting the site</li>
@@ -56,7 +56,7 @@
                     </tr>
                     <tr>
                         <td>_gat_gtag_UA_112932657_1</td>
-                        <td>Used to distinguish anonymous users</td>
+                        <td>Throttle requests</td>
                         <td>10 minutes</td>
                     </tr>
                 </tbody>
@@ -67,7 +67,7 @@
 
         <h3 class="heading-medium">Our introductory message</h2>
 
-        <p>You may see a pop-up welcome message when you first visit Find postgraduate teacher training. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+        <p>You may see a pop-up welcome message when you first visit ‘Find postgraduate teacher training’. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
 
         <div class="body-text">
             <table>

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -100,7 +100,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>b90b2935d687fb546d80508b818e20d3</td>
+                        <td><span class="break-word">b90b2935d687fb546d80508b818e20d3</span></td>
                         <td>Load balancing</td>
                         <td>never</td>
                     </tr>

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -1,0 +1,14 @@
+
+@{
+    ViewBag.Title = $"Cookies page ";
+}
+
+
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <h1 class="heading-large" role="heading">
+            Cookies
+        </h1>
+    </div>
+</div>

--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -1,41 +1,40 @@
  @{ ViewBag.Title = $"Cookies"; }
 
-<article class="text" id="content">
-    <h1 class="heading-xlarge">Cookies</h1>
+<h1 class="heading-xlarge">Cookies</h1>
 
-    <div class="grid">
-        <div class="column-two-thirds">
-            <p>Find postgraduate teacher training puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <p>Find postgraduate teacher training puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
 
-            <p class="heading-medium">Cookies are used to</p>
-            <ul class="list-bullet">
-                <li>measure how you use the website so it can be updated and improved based on your needs</li>
-                <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
-                <li>remember who you are when you have logged in so we can show you your information and information relevant to you</li>
-            </ul>
+        <p>Cookies are used to:</p>
+        <ul class="list list-bullet">
+            <li>measure how you use the website so it can be updated and improved based on your needs</li>
+            <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+            <li>remember who you are when you have logged in so we can show you your information and information relevant to you</li>
+        </ul>
 
-            <p>Find postgraduate teacher training cookies aren’t used to identify you personally.</p>
-            <p>Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.</p>
+        <p>Find postgraduate teacher training cookies aren’t used to identify you personally.</p>
+        <p>Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.</p>
 
-            <p class="heading-medium">How we use cookies</p>
-            <p class="heading-small">Measuring website usage (Google Analytics)</p>
-            <p>We use Google Analytics software to collect information about how you use Find postgraduate teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
+        <h2 class="heading-large">How we use cookies</h2>
 
-            <p class="heading-medium">Google Analytics stores information about:</p>
+        <h3 class="heading-medium">Measuring website usage (Google Analytics)</h3>
 
-            <ul class="list-bullet">
-                <li>the pages you visit on Find postgraduate teacher training</li>
-                <li>how long you spend on each page</li>
-                <li>how you got to the site</li>
-                <li>what you click on while you’re visiting the site</li>
-            </ul>
+        <p>We use Google Analytics software to collect information about how you use Find postgraduate teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
 
-            <div class="panel-indent">
-                <p>We don’t allow Google to use or share our analytics data.</p>
-            </div>
+        <p>Google Analytics stores information about:</p>
+        <ul class="list list-bullet">
+            <li>the pages you visit on Find postgraduate teacher training</li>
+            <li>how long you spend on each page</li>
+            <li>how you got to the site</li>
+            <li>what you click on while you’re visiting the site</li>
+        </ul>
 
-            <p class="heading-medium">Google Analytics sets the following cookies:</p>
+        <p>We don’t allow Google to use or share our analytics data.</p>
 
+        <p>Google Analytics sets the following cookies:</p>
+
+        <div class="body-text">
             <table>
                 <thead>
                     <tr>
@@ -62,55 +61,51 @@
                     </tr>
                 </tbody>
             </table>
+        </div>
 
-            <p>You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external">Google Analytics</a>.</p>
+        <p>You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external">Google Analytics</a>.</p>
 
-            <p class="heading-medium">Our introductory message</p>
+        <h3 class="heading-medium">Our introductory message</h2>
 
-            <p>You may see a pop-up welcome message when you first visit Find postgraduate teacher training. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+        <p>You may see a pop-up welcome message when you first visit Find postgraduate teacher training. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+
+        <div class="body-text">
             <table>
-
                 <thead>
                     <tr>
-
                         <th>Name</th>
                         <th>Purpose</th>
                         <th>Expires</th>
-
                     </tr>
                 </thead>
-
                 <tbody>
                     <tr>
                         <td>seen_cookie_message</td>
                         <td>Show cookie policy banner on first visit only</td>
                         <td>1 month</td>
-
                     </tr>
                 </tbody>
             </table>
+        </div>
 
-            <p>Other Find postgraduate teacher training cookies may include:</p>
+        <p>Other Find postgraduate teacher training cookies may include:</p>
+        <div class="body-text">
             <table>
                 <thead>
                     <tr>
-
                         <th>Name</th>
                         <th>Purpose</th>
                         <th>Expires</th>
-
                     </tr>
                 </thead>
-
                 <tbody>
                     <tr>
                         <td>b90b2935d687fb546d80508b818e20d3</td>
                         <td>Load balancing</td>
                         <td>never</td>
-
                     </tr>
                 </tbody>
             </table>
         </div>
     </div>
-</article>
+</div>

--- a/src/Views/Legal/Privacy.cshtml
+++ b/src/Views/Legal/Privacy.cshtml
@@ -1,12 +1,28 @@
+ @{ ViewBag.Title = $"Privacy Policy"; }
 
-@{
-    ViewBag.Title = $"Privacy Policy page ";
-}
+<h1 class="heading-xlarge">Privacy Policy</h1>
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h1 class="heading-large" role="heading">
-            Privacy Policy
-        </h1>
+        <p>This page explains our privacy policy and how we will use and protect any information about you that you give us when you visit this website. This privacy statement only covers the Search to Become a Teacher website. It does not cover all sites that can be linked to from this site, so you should always be aware when you are moving to another site and read the privacy statement on that site.</p>
+
+        <h2 class="heading-large">What information do we collect?</h2>
+        <p>
+            If you are a user with general public and anonymous access, the Search to Become a Teacher website does not capture or store personal information about you but simply logs your IP address, which is automatically recognised by our web server. We will then use this data to track traffic to the service and continuously improve our service to better meet users’ needs. The site does not use cookies to collect user information. We collect one type of information from visitors to this website: feedback
+
+        </p>
+        <h3 class="heading-large">Feedback</h3>
+        <p>
+            We welcome your feedback. If you contact us asking for information, we may need to contact other government departments to find that information. We do not pass on any of your personal information when dealing with your enquiry, unless you have given us permission to do so. Once we have replied to you, we keep a record of your message for audit purposes.
+        </p>
+
+        <h2 class="heading-large">The Data Protection Act</h2>
+        <p>
+            Under the Data Protection Act, we have a legal duty to protect any information we collect from you. We use leading technologies and encryption software to safeguard your data, and keep strict security standards to prevent any unauthorised access to it. We do not pass on your details to any third party or other government department unless specifically stated.
+        </p>
+        <h2 class="heading-large">Changes to this privacy policy</h2>
+        <p>
+            If this privacy policy changes in any way, we will place an updated version on this page. Regularly reviewing this page ensures you are always aware of what information we collect, how we use it and under what circumstances, if any, we will share it with other parties.
+        </p>
     </div>
 </div>

--- a/src/Views/Legal/Privacy.cshtml
+++ b/src/Views/Legal/Privacy.cshtml
@@ -3,8 +3,6 @@
     ViewBag.Title = $"Privacy Policy page ";
 }
 
-
-
 <div class="grid-row">
     <div class="column-two-thirds">
         <h1 class="heading-large" role="heading">

--- a/src/Views/Legal/Privacy.cshtml
+++ b/src/Views/Legal/Privacy.cshtml
@@ -1,0 +1,14 @@
+
+@{
+    ViewBag.Title = $"Privacy Policy page ";
+}
+
+
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <h1 class="heading-large" role="heading">
+            Privacy Policy
+        </h1>
+    </div>
+</div>

--- a/src/Views/Legal/Privacy.cshtml
+++ b/src/Views/Legal/Privacy.cshtml
@@ -4,26 +4,51 @@
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <p>This page explains our privacy policy and how we will use and protect any information about you that you give us when you visit this website. This privacy statement only covers the Search to Become a Teacher website. It does not cover all sites that can be linked to from this site, so you should always be aware when you are moving to another site and read the privacy statement on that site.</p>
+        <h2 class="heading-large">Who we are</h2>
+        <p>This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Find postgraduate teacher training’.</p>
 
-        <h2 class="heading-large">What information do we collect?</h2>
-        <p>
-            If you are a user with general public and anonymous access, the Search to Become a Teacher website does not capture or store personal information about you but simply logs your IP address, which is automatically recognised by our web server. We will then use this data to track traffic to the service and continuously improve our service to better meet users’ needs. The site does not use cookies to collect user information. We collect one type of information from visitors to this website: feedback.
+        <h2 class="heading-large">How we will use your information</h2>
+        <p>We receive your personal data in the form of your IP address and are processing it in order to track traffic to the service and continuously improve our service to better meet users’ needs. In some instances, we may also collect your email address for similar purposes. More information about this work is available if you wish to contact us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.
         </p>
 
-        <h3 class="heading-medium">Feedback</h3>
-        <p>
-            We welcome your feedback. If you contact us asking for information, we may need to contact other government departments to find that information. We do not pass on any of your personal information when dealing with your enquiry, unless you have given us permission to do so. Once we have replied to you, we keep a record of your message for audit purposes.
+        <h3 class="heading-medium">The nature of your personal data we will be using</h3>
+        <p>The categories of your personal data that we will be using for this project are: IP address and contact information - email address.
         </p>
 
-        <h2 class="heading-large">The Data Protection Act</h2>
-        <p>
-            Under the Data Protection Act, we have a legal duty to protect any information we collect from you. We use leading technologies and encryption software to safeguard your data, and keep strict security standards to prevent any unauthorised access to it. We do not pass on your details to any third party or other government department unless specifically stated.
+        <h2 class="heading-large">Why our use of your personal data is lawful</h2>
+        <p>In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this project, this processing is necessary to complete a task in the public interest.
         </p>
-        
-        <h2 class="heading-large">Changes to this privacy policy</h2>
+
+        <h2 class="heading-large">How long we will keep your personal data</h2>
+        <p>We will only keep your personal data for as long as we need it for the purpose(s) of this piece of work, after which point it will be securely destroyed. Please note that under data protection legislation and in compliance with the relevant data processing conditions, we can lawfully keep personal data processed purely for research and statistical purposes indefinitely.
+        </p>
+
+        <h2 class="heading-large">Your data protection rights</h2>
+        <p>You have the right:</p>
+        <ul class="list list-bullet">
+            <li>to ask us for access to information about you that we hold</li>
+            <li>to have your personal data rectified, if it is inaccurate or incomplete</li>
+            <li>to request the deletion or removal of personal data where there is no compelling reason for its continued processing</li>
+            <li>to restrict our processing of your personal data (i.e. permitting its storage but no further processing)</li>
+            <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
+            <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
+        </ul>
+
         <p>
-            If this privacy policy changes in any way, we will place an updated version on this page. Regularly reviewing this page ensures you are always aware of what information we collect, how we use it and under what circumstances, if any, we will share it with other parties.
+            You can <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights">find out more about your data protection rights</a> on the Information Commissioner’s website.
+        </p>
+
+        <h2 class="heading-large">The right to lodge a complaint</h2>
+
+        <p>You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <a href="https://ico.org.uk/concerns/">https://ico.org.uk/concerns/</a>.
+        </p>
+        <h2 class="heading-large">Last updated</h2>
+        <p>This version was last updated on 30 April 2018.
+        </p>
+        <h2 class="heading-large">Contact us</h2>
+
+        <p>
+            Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you have any questions about how your personal information will be processed.
         </p>
     </div>
 </div>

--- a/src/Views/Legal/Privacy.cshtml
+++ b/src/Views/Legal/Privacy.cshtml
@@ -1,6 +1,6 @@
- @{ ViewBag.Title = $"Privacy Policy"; }
+ @{ ViewBag.Title = $"Privacy policy"; }
 
-<h1 class="heading-xlarge">Privacy Policy</h1>
+<h1 class="heading-xlarge">Privacy policy</h1>
 
 <div class="grid-row">
     <div class="column-two-thirds">
@@ -8,10 +8,10 @@
 
         <h2 class="heading-large">What information do we collect?</h2>
         <p>
-            If you are a user with general public and anonymous access, the Search to Become a Teacher website does not capture or store personal information about you but simply logs your IP address, which is automatically recognised by our web server. We will then use this data to track traffic to the service and continuously improve our service to better meet users’ needs. The site does not use cookies to collect user information. We collect one type of information from visitors to this website: feedback
-
+            If you are a user with general public and anonymous access, the Search to Become a Teacher website does not capture or store personal information about you but simply logs your IP address, which is automatically recognised by our web server. We will then use this data to track traffic to the service and continuously improve our service to better meet users’ needs. The site does not use cookies to collect user information. We collect one type of information from visitors to this website: feedback.
         </p>
-        <h3 class="heading-large">Feedback</h3>
+
+        <h3 class="heading-medium">Feedback</h3>
         <p>
             We welcome your feedback. If you contact us asking for information, we may need to contact other government departments to find that information. We do not pass on any of your personal information when dealing with your enquiry, unless you have given us permission to do so. Once we have replied to you, we keep a record of your message for audit purposes.
         </p>
@@ -20,6 +20,7 @@
         <p>
             Under the Data Protection Act, we have a legal duty to protect any information we collect from you. We use leading technologies and encryption software to safeguard your data, and keep strict security standards to prevent any unauthorised access to it. We do not pass on your details to any third party or other government department unless specifically stated.
         </p>
+        
         <h2 class="heading-large">Changes to this privacy policy</h2>
         <p>
             If this privacy policy changes in any way, we will place an updated version on this page. Regularly reviewing this page ensures you are always aware of what information we collect, how we use it and under what circumstances, if any, we will share it with other parties.

--- a/src/Views/Legal/TandC.cshtml
+++ b/src/Views/Legal/TandC.cshtml
@@ -1,14 +1,34 @@
+ @{ ViewBag.Title = $"Terms and Conditions "; }
 
-@{
-    ViewBag.Title = $"Terms and Conditions page ";
-}
-
-
+<h1 class="heading-xlarge">Terms and Conditions</h1>
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h1 class="heading-large" role="heading">
-            Terms and Conditions
-        </h1>
+        <h2 class="heading-large">Using our website</h2>
+        <p>
+            The Find postgraduate teacher training website is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website.
+        </p>
+
+        <h2 class="heading-large">Hyperlinking to the Find postgraduate teacher training website</h2>
+        <p>
+            We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The Find postgraduate teacher training pages must be displayed in the user's entire browser window.
+        </p>
+
+        <h2 class="heading-large">Hyperlinking from the Find postgraduate teacher training website</h2>
+        <p>
+            We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them. We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
+        </p>
+
+        <h2 class="heading-large">Virus protection</h2>
+        <p>
+            We make every effort to check and test material at all stages of production. It is always wise for you to run an anti-virus program on all material downloaded from the Internet. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
+        </p>
+
+        <h2 class="heading-large">Disclaimer</h2>
+        <p>The Find postgraduate teacher training website and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
+
+        <p>We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the Find postgraduate teacher training website</p>
+
+        <p>These Terms and Conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these Terms and Conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
     </div>
 </div>

--- a/src/Views/Legal/TandC.cshtml
+++ b/src/Views/Legal/TandC.cshtml
@@ -6,15 +6,15 @@
     <div class="column-two-thirds">
         <h2 class="heading-large">Using our website</h2>
         <p>
-            The Find postgraduate teacher training website is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website.
+            The ‘Find postgraduate teacher training’ service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.
         </p>
 
-        <h2 class="heading-large">Hyperlinking to the Find postgraduate teacher training website</h2>
+        <h2 class="heading-large">Hyperlinking to Find postgraduate teacher training </h2>
         <p>
-            We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The Find postgraduate teacher training pages must be displayed in the user's entire browser window.
+            We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find postgraduate teacher training’ pages must be displayed in the user's entire browser window.
         </p>
 
-        <h2 class="heading-large">Hyperlinking from the Find postgraduate teacher training website</h2>
+        <h2 class="heading-large">Hyperlinking from Find postgraduate teacher training</h2>
         <p>
             We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them. We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
         </p>
@@ -25,10 +25,10 @@
         </p>
 
         <h2 class="heading-large">Disclaimer</h2>
-        <p>The Find postgraduate teacher training website and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
+        <p>‘Find postgraduate teacher training’ and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
 
-        <p>We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the Find postgraduate teacher training website</p>
+        <p>We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the ‘Find postgraduate teacher training’</p>
 
-        <p>These Terms and Conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these Terms and Conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+        <p>These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
     </div>
 </div>

--- a/src/Views/Legal/TandC.cshtml
+++ b/src/Views/Legal/TandC.cshtml
@@ -1,0 +1,14 @@
+
+@{
+    ViewBag.Title = $"Terms and Conditions page ";
+}
+
+
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <h1 class="heading-large" role="heading">
+            Terms and Conditions
+        </h1>
+    </div>
+</div>

--- a/src/Views/Legal/TandC.cshtml
+++ b/src/Views/Legal/TandC.cshtml
@@ -1,4 +1,4 @@
- @{ ViewBag.Title = $"Terms and Conditions "; }
+ @{ ViewBag.Title = $"Terms and Conditions"; }
 
 <h1 class="heading-xlarge">Terms and Conditions</h1>
 
@@ -25,7 +25,7 @@
         </p>
 
         <h2 class="heading-large">Disclaimer</h2>
-        <p>‘Find postgraduate teacher training’ and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
+        <p>‘Find postgraduate teacher training’ and material relating to government information, products and services (or to third party information, products and services), is provided ‘as is’, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
 
         <p>We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the ‘Find postgraduate teacher training’</p>
 

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -41,6 +41,16 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112932657-1"></script>
 }
 
+@section footerSupportLinks {
+    <h2 class="visuallyhidden">Support links</h2>
+    <ul>
+        <li><a href="mailto:becomingateacher@digital.education.gov.uk?subject=Search%20beta%20feedback">Give feedback</a></li>
+        <li><a href="/cookies">Cookies</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms-conditions">Terms and conditions</a></li>
+        </li>
+    </ul>
+}
 
 <main role="main">
     <div class="phase-banner-wrapper">

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -48,7 +48,6 @@
         <li><a href="/cookies">Cookies</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms-conditions">Terms and conditions</a></li>
-        </li>
     </ul>
 }
 

--- a/src/Views/Shared/_Layout_base.cshtml
+++ b/src/Views/Shared/_Layout_base.cshtml
@@ -57,7 +57,7 @@
             RenderSection("cookieMessage");
         }
         else {
-            <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+            <p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
         }
     </div>
 
@@ -90,7 +90,7 @@
 
         <div class="footer-meta">
           <div class="footer-meta-inner">
-            @RenderSection("footerSupportLinks", required: false)
+            @RenderSection("footerSupportLinks", required: true)
 
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -409,3 +409,9 @@ table.alt th
     background-color: #fff8c4;
     border-bottom: 1px solid #bfc1c3;
 }
+
+.break-word {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+}


### PR DESCRIPTION
# Added Cookies, Privacy Policy and, Terms and Condition pages


Urls 
* site/cookies
* site/privacy-policy
* site/terms-conditions

Updated footer to have the links for the above pages. 
Updated footer to have mailto link for 'Give feedback'
 
## Cookies page
![localhost_5000_cookies](https://user-images.githubusercontent.com/470137/39429525-05155b26-4c83-11e8-9eae-4b2971ef892e.png)

## Privacy Policy page (updated)
![localhost_5000_privacy-policy](https://user-images.githubusercontent.com/470137/39431854-e5db5fba-4c89-11e8-9588-37d102574534.png)


## Terms and Condition page
![localhost_5000_terms-conditions](https://user-images.githubusercontent.com/470137/39429557-1c1ceb22-4c83-11e8-9b78-245940c3bf45.png)

## Footer section
![footer](https://user-images.githubusercontent.com/470137/39429479-e8e2c52e-4c82-11e8-91b7-2e84a654a874.PNG)
