### PR TITLE
Remove training provider code name

### DIFF
--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -267,7 +267,6 @@
                     You'll need these codes for the Choices section of the application form:
                 </p>
                 <ul class="list list-bullet">
-                    <li>training provider code name: @Model.Course.ProviderCodeName</li>
                     <li>training provider code: @Model.Course.Provider.ProviderCode</li>
                     <li>training programme code: @Model.Course.ProgrammeCode</li>
                     @if (Model.Course.Campuses.Count() == 0) {


### PR DESCRIPTION
The provider code name is not used in the UCAS application process.
Only the provider code and programme code are needed.