### PR TITLE
Add link to UCAS course page where full details unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 sassobj
 node_modules
 *.tmp
+.vs

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local-packages" value="../search-and-compare-api/src/domain/publish" />
+    <!-- uncomment this for local development  of API+UI -->
+    <!-- <add key="local-packages" value="../search-and-compare-api/src/domain/publish" /> -->
   </packageSources>
 </configuration>

--- a/SearchAndCompareUI.sln
+++ b/SearchAndCompareUI.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchAndCompareUi", "src\SearchAndCompareUi.csproj", "{83AA01DC-6869-4403-91C3-FE45F9C6B946}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUi", "src\SearchAndCompareUi.csproj", "{83AA01DC-6869-4403-91C3-FE45F9C6B946}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchAndCompareUI.Tests", "tests\SearchAndCompareUI.Tests.csproj", "{E6BC67D7-901E-49B6-909E-5C3C699D6194}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUI.Tests", "tests\SearchAndCompareUI.Tests.csproj", "{E6BC67D7-901E-49B6-909E-5C3C699D6194}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,33 +15,36 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.ActiveCfg = Debug|x64
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.Build.0 = Debug|x64
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.ActiveCfg = Debug|x86
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.Build.0 = Debug|x86
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.Build.0 = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.Build.0 = Debug|Any CPU
 		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.Build.0 = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.ActiveCfg = Release|x64
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.Build.0 = Release|x64
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.ActiveCfg = Release|x86
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.Build.0 = Release|x86
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.ActiveCfg = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.Build.0 = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.ActiveCfg = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.Build.0 = Release|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x64.ActiveCfg = Debug|x64
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x64.Build.0 = Debug|x64
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x86.ActiveCfg = Debug|x86
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x86.Build.0 = Debug|x86
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x86.Build.0 = Debug|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x64.ActiveCfg = Release|x64
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x64.Build.0 = Release|x64
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.ActiveCfg = Release|x86
-		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.Build.0 = Release|x86
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x64.Build.0 = Release|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EE7EE0FF-7E99-483A-8A24-E8375341C05A}
 	EndGlobalSection
 EndGlobal

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -38,11 +38,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             return View(viewModel);
         }
 
-        [HttpGet("course/ucas-redirect", Name = "RedirectToUcasCourse")]
-        public RedirectResult RedirectToUcasCourse(string programmeCode, string providerCode)
+        [HttpGet("course/{courseId:int}/ucas-redirect", Name = "RedirectToUcasCourse")]
+        public RedirectResult RedirectToUcasCourse(int courseId)
         {
             var url = "some url";
-            // var url = _api.GetUcasCourseUrl(programmeCode, providerCode);
+            // var url = _api.GetUcasCourseUrl(courseId);
 
             return new RedirectResult(url);
         }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -38,10 +38,13 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             return View(viewModel);
         }
 
-        [HttpGet("course/ucas-redirect/{courseId:int}", Name = "RedirectToUcasCourse")]
-        public RedirectResult RedirectToUcasCourse(int courseId, ResultsFilter filter)
+        [HttpGet("course/ucas-redirect", Name = "RedirectToUcasCourse")]
+        public RedirectResult RedirectToUcasCourse(string programmeCode, string providerCode)
         {
-            return new RedirectResult("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run");
+            var url = "some url";
+            // var url = _api.GetUcasCourseUrl(programmeCode, providerCode);
+
+            return new RedirectResult(url);
         }
     }
 }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -37,5 +37,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             return View(viewModel);
         }
+
+        [HttpGet("course/ucas-redirect/{courseId:int}", Name = "RedirectToUcasCourse")]
+        public RedirectResult RedirectToUcasCourse(int courseId, ResultsFilter filter)
+        {
+            return new RedirectResult("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run");
+        }
     }
 }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -41,8 +41,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("course/{courseId:int}/ucas-redirect", Name = "RedirectToUcasCourse")]
         public RedirectResult RedirectToUcasCourse(int courseId)
         {
-            var url = "some url";
-            // var url = _api.GetUcasCourseUrl(courseId);
+            var url = _api.GetUcasCourseUrl(courseId);
 
             return new RedirectResult(url);
         }

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:63762/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SearchAndCompareUi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:63773/"
+    }
+  }
+}

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.2.3-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.3.0-beta" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewBag.Title = $"{Model.Course.Name} at {Model.Provider.Name}";
+    var showMinimal = !Model.HasSection("about this training programme");
 }
 
 @Html.Partial("Back", new BackLinkViewModel {
@@ -64,164 +65,166 @@
         </div>
     </div>
 </div>
-<br />
-<div class="grid-row">
-    <div class="column-full">
-        <div class="course-contents">
-            <div class="panel panel-border-narrow">
 
-            <a href="@Url.Action("RedirectToUcasCourse", "Course", new {
-                courseId = Model.Course.Id
-            })">Full details of this course are available on UCAS</a>
-            </div>
-        </div>
-    </div>
-</div>
+
 <div class="grid-row">
+
     <div class="column-two-thirds">
-        <div class="course-contents">
-            <h2 class="heading-small">Contents</h2>
-            <ul role="directory">
-                @if (Model.HasSection("about this training programme")) {
-                    <li><a href="#section-about">About the course</a></li>
-                }
-                @if (Model.HasSection("entry requirements")) {
-                    <li><a href="#section-entry">Requirements</a></li>
-                }
-                @if (Model.HasSection("about placement schools")) {
-                    <li><a href="#section-schools">Placement schools</a></li>
-                }
 
-                <li><a href="#section-fees">Fees</a></li>
-
-                <li><a href="#section-financial-support">Financial support</a></li>
-
-                @if (Model.HasSection("about this training provider")) {
-                <li><a href="#section-about-provider">About the training provider</a></li>
-                }
-
-                @if (Model.HasContactDetails()) {
-                <li><a href="#section-contact">Contact details</a></li>
-                }
-
-                <li><a href="#section-apply">Apply</a></li>
-            </ul>
-        </div>
-
-        @if (Model.HasSection("about this training programme")) {
-            <div class="course-details-section">
-                <h2 class="heading-medium" id="section-about">
-                    About the course
-                </h2>
-                <div>
-                    @Html.Raw(Model.GetHtmlForSection("about this training programme"))
-                </div>
+        @if(showMinimal) {
+            <div class="panel panel-border-wide">
+                <a href="@Url.Action("RedirectToUcasCourse", "Course", new {
+                courseId = Model.Course.Id
+                })">Full details of this course are available on UCAS</a>
             </div>
         }
 
-        @if (Model.HasSection("entry requirements")) {
-            <div class="course-details-section">
+        @if(!showMinimal) {
+            <div class="course-contents">
+                <h2 class="heading-small">Contents</h2>
+                <ul role="directory">
+                    @if (Model.HasSection("about this training programme")) {
+                        <li><a href="#section-about">About the course</a></li>
+                    }
+                    @if (Model.HasSection("entry requirements")) {
+                        <li><a href="#section-entry">Requirements</a></li>
+                    }
+                    @if (Model.HasSection("about placement schools")) {
+                        <li><a href="#section-schools">Placement schools</a></li>
+                    }
+
+                    <li><a href="#section-fees">Fees</a></li>
+
+                    <li><a href="#section-financial-support">Financial support</a></li>
+
+                    @if (Model.HasSection("about this training provider")) {
+                    <li><a href="#section-about-provider">About the training provider</a></li>
+                    }
+
+                    @if (Model.HasContactDetails()) {
+                    <li><a href="#section-contact">Contact details</a></li>
+                    }
+
+                    <li><a href="#section-apply">Apply</a></li>
+                </ul>
+            </div>
+
+
+            @if (Model.HasSection("about this training programme")) {
+                <div class="course-details-section">
+                    <h2 class="heading-medium" id="section-about">
+                        About the course
+                    </h2>
+                    <div>
+                        @Html.Raw(Model.GetHtmlForSection("about this training programme"))
+                    </div>
+                </div>
+            }
+
+            @if (Model.HasSection("entry requirements")) {
+                <div class="course-details-section">
                 <h2 class="heading-medium" id="section-entry">
-                    Requirements
+                        Requirements
                 </h2>
-                <div>
-                    @Html.Raw(Model.GetHtmlForSection("entry requirements"))
+                    <div>
+                        @Html.Raw(Model.GetHtmlForSection("entry requirements"))
+                    </div>
                 </div>
-            </div>
-        }
+            }
 
-        @if (Model.HasSection("about placement schools")) {
-            <div class="course-details-section">
+            @if (Model.HasSection("about placement schools")) {
+                <div class="course-details-section">
                 <h2 class="heading-medium" id="section-schools">
-                    Placement schools
+                        Placement schools
                 </h2>
-                <div>
-                    @Html.Raw(Model.GetHtmlForSection("about placement schools"))
-                </div>
-                @* PRIVATE_BETA_HACK
-                <div>
-                    <p>
-                        Placement schools are also known as partner schools.
-                    </p>
-                    <table class="alt">
-                        <tr>
-                            <th>Name</th>
-                            <th>Address</th>
-                            <th>Code</th>
-                            <th>Vacancies</th>
-                            <th>Study type</th>
-                        </tr>
-                        @foreach(var campus in Model.Course.Campuses) {
+                    <div>
+                        @Html.Raw(Model.GetHtmlForSection("about placement schools"))
+                    </div>
+                    @* PRIVATE_BETA_HACK
+                    <div>
+                        <p>
+                            Placement schools are also known as partner schools.
+                        </p>
+                        <table class="alt">
                             <tr>
-                                <td>@campus.Name</td>
-                                <td>@campus.Location?.Address</td>
-                                <td>@campus.CampusCode</td>
-                                <td>@Model.Course.VacanciesUiString()</td>
-                                <td>@Model.Course.StudyTypeUiString()</td>
+                                <th>Name</th>
+                                <th>Address</th>
+                                <th>Code</th>
+                                <th>Vacancies</th>
+                                <th>Study type</th>
                             </tr>
-                        }
+                            @foreach(var campus in Model.Course.Campuses) {
+                                <tr>
+                                    <td>@campus.Name</td>
+                                    <td>@campus.Location?.Address</td>
+                                    <td>@campus.CampusCode</td>
+                                    <td>@Model.Course.VacanciesUiString()</td>
+                                    <td>@Model.Course.StudyTypeUiString()</td>
+                                </tr>
+                            }
 
-                    </table>
-                </div> *@
-            </div>
-        }
-
-        <div class="course-details-section">
-            <div>
-                <h2 class="heading-medium" id="section-fees">Fees</h2>
-                <p>The course fees for @Model.Finance.FormattedYear are as follows:</p>
-                <div class="body-text">
-                  <table>
-                      <tr class="visually-hidden">
-                          <th>Student type</th><th>Fees to pay</th>
-                      </tr>
-                      <tr>
-                          <td>UK students</td><td>@Model.Finance.FormattedUkFees</td>
-                      </tr>
-                      <tr>
-                          <td>EU students</td><td>@Model.Finance.FormattedEuFees</td>
-                      </tr>
-                  </table>
+                        </table>
+                    </div> *@
                 </div>
+            }
+
+            <div class="course-details-section">
+                <div>
+                <h2 class="heading-medium" id="section-fees">Fees</h2>
+                    <p>The course fees for @Model.Finance.FormattedYear are as follows:</p>
+                    <div class="body-text">
+                    <table>
+                        <tr class="visually-hidden">
+                            <th>Student type</th><th>Fees to pay</th>
+                        </tr>
+                        <tr>
+                            <td>UK students</td><td>@Model.Finance.FormattedUkFees</td>
+                        </tr>
+                        <tr>
+                            <td>EU students</td><td>@Model.Finance.FormattedEuFees</td>
+                        </tr>
+                    </table>
+                    </div>
 
                 <h2 class="heading-medium" id="section-financial-support">Financial support</h2>
-                @if (Model.Finance.IsSalaried) {
-                    <p>
-                        @Model.Finance.FormattedSalary
-                    </p>
-                } else if (Model.Finance.HasFunding) {
-                    <p>The following financial support might be available for you depending on your qualifications.</p>
-                    <ul class="list list-bullet">
-                        @if (Model.Finance.MaxScholarship.HasValue) {
-                            <li>@Model.Finance.FormattedMaxScholarship</li>
-                        }
-                        @if (Model.Finance.MaxBursary.HasValue) {
-                            <li>@Model.Finance.FormattedMaxBursary</li>
-                        }
-                    </ul>
+                    @if (Model.Finance.IsSalaried) {
+                        <p>
+                            @Model.Finance.FormattedSalary
+                        </p>
+                    } else if (Model.Finance.HasFunding) {
+                        <p>The following financial support might be available for you depending on your qualifications.</p>
+                        <ul class="list list-bullet">
+                            @if (Model.Finance.MaxScholarship.HasValue) {
+                                <li>@Model.Finance.FormattedMaxScholarship</li>
+                            }
+                            @if (Model.Finance.MaxBursary.HasValue) {
+                                <li>@Model.Finance.FormattedMaxBursary</li>
+                            }
+                        </ul>
                 } else {
                   <p>
                       You may be eligible for <a href="https://www.gov.uk/student-finance">financial support for students</a>.
                   </p>
-                }
+                    }
 
-                <p>
+                    <p>
                     <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">Financial support if you’re from outside of the UK</a>
-                </p>
-            </div>
-        </div>
-
-        @if (Model.HasSection("about this training provider")) {
-            <div class="course-details-section">
-                <h2 class="heading-medium" id="section-about-provider">
-                    About the training provider
-                </h2>
-                <div>
-                    @Html.Raw(Model.GetHtmlForSection("about this training provider"))
+                    </p>
                 </div>
             </div>
-        }
 
+            @if (Model.HasSection("about this training provider")) {
+                <div class="course-details-section">
+                <h2 class="heading-medium" id="section-about-provider">
+                        About the training provider
+                </h2>
+                    <div>
+                        @Html.Raw(Model.GetHtmlForSection("about this training provider"))
+                    </div>
+                </div>
+            }
+
+        }
         @if (Model.HasContactDetails()) {
             <div class="course-details-section">
                 <h2 class="heading-medium" id="section-contact">

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -69,7 +69,11 @@
     <div class="column-full">
         <div class="course-contents">
             <div class="panel panel-border-narrow">
-                <a href="/course/ucas-redirect/1">Full details of this course are available on UCAS</a>
+
+            <a href="@Url.Action("RedirectToUcasCourse", "Course", new {
+                ProgrammeCode = Model.Course.ProgrammeCode,
+                ProviderCode = Model.Course.Provider.ProviderCode
+            })">Full details of this course are available on UCAS</a>
             </div>
         </div>
     </div>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -71,8 +71,7 @@
             <div class="panel panel-border-narrow">
 
             <a href="@Url.Action("RedirectToUcasCourse", "Course", new {
-                ProgrammeCode = Model.Course.ProgrammeCode,
-                ProviderCode = Model.Course.Provider.ProviderCode
+                courseId = Model.Course.Id
             })">Full details of this course are available on UCAS</a>
             </div>
         </div>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -5,7 +5,8 @@
     var showMinimal = !Model.HasSection("about this training programme");
 }
 
-@Html.Partial("Back", new BackLinkViewModel {
+@Html.Partial("Back", new BackLinkViewModel
+{
     Href = Url.Action("Index", "Results", Model.FilterModel.ToRouteValues()),
     Title = "Back to search results"
 })
@@ -19,31 +20,35 @@
     <div class="column-full">
         <div class="course-basicinfo">
             <dl role="contentinfo">
-                @if (Model.Course.ProviderLocation != null) {
+                @if (Model.Course.ProviderLocation != null)
+                {
                     <dt>Location</dt>
                     <dd>@Model.Course.ProviderLocation.Address</dd>
                 }
                 <dt>Qualification</dt>
                 <dd>
-                    @if (Model.Course.IncludesPgce != IncludesPgce.No) {
-                    <details>
-                        <summary><span class="summary">@Model.Course.FormattedOutcome()</span></summary>
+                    @if (Model.Course.IncludesPgce != IncludesPgce.No)
+                    {
+                        <details>
+                            <summary><span class="summary">@Model.Course.FormattedOutcome()</span></summary>
 
-                        <div class="panel panel-border-narrow">
-                            <p>A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) allows you to teach in England, Scotland, Wales and Northern Ireland.</p>
-                            <p>This qualification is also recognised internationally.</p>
-                            <p>Many PGCE courses include credits that count toward a Master&#8217;s degree.</p>
-                        </div>
-                    </details>
-                    } else {
-                    <details>
-                        <summary><span class="summary">@Model.Course.FormattedOutcome()</span></summary>
+                            <div class="panel panel-border-narrow">
+                                <p>A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) allows you to teach in England, Scotland, Wales and Northern Ireland.</p>
+                                <p>This qualification is also recognised internationally.</p>
+                                <p>Many PGCE courses include credits that count toward a Master&#8217;s degree.</p>
+                            </div>
+                        </details>
+                    }
+                    else
+                    {
+                        <details>
+                            <summary><span class="summary">@Model.Course.FormattedOutcome()</span></summary>
 
-                        <div class="panel panel-border-narrow">
-                            <p>Qualified teacher status (QTS) allows you to teach in state schools in England.</p>
-                            <p>If you want to teach in the rest of the UK or internationally, consider a course that gives you the qualification &#39;postgraduate certificate in education with qualified teacher status&#39; instead.</p>
-                        </div>
-                    </details>
+                            <div class="panel panel-border-narrow">
+                                <p>Qualified teacher status (QTS) allows you to teach in state schools in England.</p>
+                                <p>If you want to teach in the rest of the UK or internationally, consider a course that gives you the qualification &#39;postgraduate certificate in education with qualified teacher status&#39; instead.</p>
+                            </div>
+                        </details>
                     }
                 </dd>
 
@@ -71,7 +76,8 @@
 
     <div class="column-two-thirds">
 
-        @if(showMinimal) {
+        @if (showMinimal)
+        {
             <div class="panel panel-border-wide">
                 <a href="@Url.Action("RedirectToUcasCourse", "Course", new {
                 courseId = Model.Course.Id
@@ -79,17 +85,21 @@
             </div>
         }
 
-        @if(!showMinimal) {
+        @if (!showMinimal)
+        {
             <div class="course-contents">
                 <h2 class="heading-small">Contents</h2>
                 <ul role="directory">
-                    @if (Model.HasSection("about this training programme")) {
+                    @if (Model.HasSection("about this training programme"))
+                    {
                         <li><a href="#section-about">About the course</a></li>
                     }
-                    @if (Model.HasSection("entry requirements")) {
+                    @if (Model.HasSection("entry requirements"))
+                    {
                         <li><a href="#section-entry">Requirements</a></li>
                     }
-                    @if (Model.HasSection("about placement schools")) {
+                    @if (Model.HasSection("about placement schools"))
+                    {
                         <li><a href="#section-schools">Placement schools</a></li>
                     }
 
@@ -97,12 +107,14 @@
 
                     <li><a href="#section-financial-support">Financial support</a></li>
 
-                    @if (Model.HasSection("about this training provider")) {
-                    <li><a href="#section-about-provider">About the training provider</a></li>
+                    @if (Model.HasSection("about this training provider"))
+                    {
+                        <li><a href="#section-about-provider">About the training provider</a></li>
                     }
 
-                    @if (Model.HasContactDetails()) {
-                    <li><a href="#section-contact">Contact details</a></li>
+                    @if (Model.HasContactDetails())
+                    {
+                        <li><a href="#section-contact">Contact details</a></li>
                     }
 
                     <li><a href="#section-apply">Apply</a></li>
@@ -110,7 +122,8 @@
             </div>
 
 
-            @if (Model.HasSection("about this training programme")) {
+            @if (Model.HasSection("about this training programme"))
+            {
                 <div class="course-details-section">
                     <h2 class="heading-medium" id="section-about">
                         About the course
@@ -121,103 +134,116 @@
                 </div>
             }
 
-            @if (Model.HasSection("entry requirements")) {
+            @if (Model.HasSection("entry requirements"))
+            {
                 <div class="course-details-section">
-                <h2 class="heading-medium" id="section-entry">
+                    <h2 class="heading-medium" id="section-entry">
                         Requirements
-                </h2>
+                    </h2>
                     <div>
                         @Html.Raw(Model.GetHtmlForSection("entry requirements"))
                     </div>
                 </div>
             }
 
-            @if (Model.HasSection("about placement schools")) {
+            @if (Model.HasSection("about placement schools"))
+            {
                 <div class="course-details-section">
-                <h2 class="heading-medium" id="section-schools">
+                    <h2 class="heading-medium" id="section-schools">
                         Placement schools
-                </h2>
+                    </h2>
                     <div>
                         @Html.Raw(Model.GetHtmlForSection("about placement schools"))
                     </div>
                     @* PRIVATE_BETA_HACK
-                    <div>
-                        <p>
-                            Placement schools are also known as partner schools.
-                        </p>
-                        <table class="alt">
-                            <tr>
-                                <th>Name</th>
-                                <th>Address</th>
-                                <th>Code</th>
-                                <th>Vacancies</th>
-                                <th>Study type</th>
-                            </tr>
-                            @foreach(var campus in Model.Course.Campuses) {
+                        <div>
+                            <p>
+                                Placement schools are also known as partner schools.
+                            </p>
+                            <table class="alt">
                                 <tr>
-                                    <td>@campus.Name</td>
-                                    <td>@campus.Location?.Address</td>
-                                    <td>@campus.CampusCode</td>
-                                    <td>@Model.Course.VacanciesUiString()</td>
-                                    <td>@Model.Course.StudyTypeUiString()</td>
+                                    <th>Name</th>
+                                    <th>Address</th>
+                                    <th>Code</th>
+                                    <th>Vacancies</th>
+                                    <th>Study type</th>
                                 </tr>
-                            }
+                                @foreach(var campus in Model.Course.Campuses) {
+                                    <tr>
+                                        <td>@campus.Name</td>
+                                        <td>@campus.Location?.Address</td>
+                                        <td>@campus.CampusCode</td>
+                                        <td>@Model.Course.VacanciesUiString()</td>
+                                        <td>@Model.Course.StudyTypeUiString()</td>
+                                    </tr>
+                                }
 
-                        </table>
-                    </div> *@
+                            </table>
+                        </div> *@
                 </div>
             }
 
             <div class="course-details-section">
                 <div>
-                <h2 class="heading-medium" id="section-fees">Fees</h2>
+                    <h2 class="heading-medium" id="section-fees">Fees</h2>
                     <p>The course fees for @Model.Finance.FormattedYear are as follows:</p>
                     <div class="body-text">
-                    <table>
-                        <tr class="visually-hidden">
-                            <th>Student type</th><th>Fees to pay</th>
-                        </tr>
-                        <tr>
-                            <td>UK students</td><td>@Model.Finance.FormattedUkFees</td>
-                        </tr>
-                        <tr>
-                            <td>EU students</td><td>@Model.Finance.FormattedEuFees</td>
-                        </tr>
-                    </table>
+                        <table>
+                            <tr class="visually-hidden">
+                                <th>Student type</th>
+                                <th>Fees to pay</th>
+                            </tr>
+                            <tr>
+                                <td>UK students</td>
+                                <td>@Model.Finance.FormattedUkFees</td>
+                            </tr>
+                            <tr>
+                                <td>EU students</td>
+                                <td>@Model.Finance.FormattedEuFees</td>
+                            </tr>
+                        </table>
                     </div>
 
-                <h2 class="heading-medium" id="section-financial-support">Financial support</h2>
-                    @if (Model.Finance.IsSalaried) {
+                    <h2 class="heading-medium" id="section-financial-support">Financial support</h2>
+                    @if (Model.Finance.IsSalaried)
+                    {
                         <p>
                             @Model.Finance.FormattedSalary
                         </p>
-                    } else if (Model.Finance.HasFunding) {
+                    }
+                    else if (Model.Finance.HasFunding)
+                    {
                         <p>The following financial support might be available for you depending on your qualifications.</p>
                         <ul class="list list-bullet">
-                            @if (Model.Finance.MaxScholarship.HasValue) {
+                            @if (Model.Finance.MaxScholarship.HasValue)
+                            {
                                 <li>@Model.Finance.FormattedMaxScholarship</li>
                             }
-                            @if (Model.Finance.MaxBursary.HasValue) {
+                            @if (Model.Finance.MaxBursary.HasValue)
+                            {
                                 <li>@Model.Finance.FormattedMaxBursary</li>
                             }
                         </ul>
-                } else {
-                  <p>
-                      You may be eligible for <a href="https://www.gov.uk/student-finance">financial support for students</a>.
-                  </p>
+                    }
+                    else
+                    {
+                        <p>
+                            You may be eligible for <a href="https://www.gov.uk/student-finance">financial support for students</a>.
+                        </p>
                     }
 
                     <p>
-                    <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">Financial support if you’re from outside of the UK</a>
+                        <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">Financial support if you’re from outside of the UK</a>
                     </p>
                 </div>
             </div>
 
-            @if (Model.HasSection("about this training provider")) {
+            @if (Model.HasSection("about this training provider"))
+            {
                 <div class="course-details-section">
-                <h2 class="heading-medium" id="section-about-provider">
+                    <h2 class="heading-medium" id="section-about-provider">
                         About the training provider
-                </h2>
+                    </h2>
                     <div>
                         @Html.Raw(Model.GetHtmlForSection("about this training provider"))
                     </div>
@@ -225,44 +251,58 @@
             }
 
         }
-        @if (Model.HasContactDetails()) {
+        @if (Model.HasContactDetails())
+        {
             <div class="course-details-section">
                 <h2 class="heading-medium" id="section-contact">
                     Contact details
                 </h2>
                 <div class="course-basicinfo">
                     <dl role="contentinfo">
-                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Email)) {
+                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Email))
+                        {
                             <dt class="bold">Email</dt>
-                            <dd><a href="mailto:@Model.Course.ContactDetails.Email"
+                            <dd>
+                                <a href="mailto:@Model.Course.ContactDetails.Email"
                                    title="Send email to course contact"
                                    aria-label="Send email to course contact">
-                                    @Model.Course.ContactDetails.Email</a></dd>
+                                    @Model.Course.ContactDetails.Email
+                                </a>
+                            </dd>
                         }
-                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Phone)) {
+                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Phone))
+                        {
                             <dt class="bold">Telephone</dt>
                             <dd>@Model.Course.ContactDetails.Phone</dd>
                         }
-                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Fax)) {
+                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Fax))
+                        {
                             <dt class="bold">Fax</dt>
                             <dd>@Model.Course.ContactDetails.Fax</dd>
                         }
-                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Website)) {
+                        @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Website))
+                        {
                             <dt class="bold">Website</dt>
-                            <dd><a href="@Model.Course.ContactDetails.Website"
+                            <dd>
+                                <a href="@Model.Course.ContactDetails.Website"
                                    title="Go to course website"
                                    aria-label="Go to course website">
-                                   @Model.Course.ContactDetails.Website</a></dd>
+                                    @Model.Course.ContactDetails.Website
+                                </a>
+                            </dd>
                         }
-                        @if (Model.HasAddress()) {
+                        @if (Model.HasAddress())
+                        {
                             <dt class="bold">Address</dt>
                             <dd>
-                            @if(!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Address)) {
-                                @foreach(var line in Model.Course.ContactDetails.Address.Split("\n")) {
-                                    @line
-                                    <br>
+                                @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Address))
+                                {
+                                    @foreach (var line in Model.Course.ContactDetails.Address.Split("\n"))
+                                    {
+                                        @line
+                                        <br>
+                                    }
                                 }
-                            }
                             </dd>
                         }
                     </dl>
@@ -285,18 +325,23 @@
                 <ul class="list list-bullet">
                     <li>training provider code: @Model.Course.Provider.ProviderCode</li>
                     <li>training programme code: @Model.Course.ProgrammeCode</li>
-                    @if (Model.Course.Campuses.Count() == 0) {
+                    @if (Model.Course.Campuses.Count() == 0)
+                    {
                         <li>training location or campus code: leave empty</li>
-                    } else if (Model.Course.Campuses.Count() == 1) {
+                    }
+                    else if (Model.Course.Campuses.Count() == 1)
+                    {
                         <li>training location or campus code: @(String.IsNullOrEmpty(Model.Course.Campuses.Single().CampusCode) ? "leave empty" : Model.Course.Campuses.Single().CampusCode)</li>
                     }
                 </ul>
-                @if (Model.Course.Campuses.Count() > 1) {
+                @if (Model.Course.Campuses.Count() > 1)
+                {
                     <p>
                         When asked for the training location or campus code, use:
                     </p>
                     <ul class="list list-bullet">
-                        @foreach(var campus in Model.Course.Campuses) {
+                        @foreach (var campus in Model.Course.Campuses)
+                        {
                             <li>@(String.IsNullOrEmpty(campus.CampusCode) ? "leave empty" : campus.CampusCode) for @campus.Name</li>
                         }
                     </ul>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -64,6 +64,16 @@
         </div>
     </div>
 </div>
+<br />
+<div class="grid-row">
+    <div class="column-full">
+        <div class="course-contents">
+            <div class="panel panel-border-narrow">
+                <a href="/course/ucas-redirect/1">Full details of this course are available on UCAS</a>
+            </div>
+        </div>
+    </div>
+</div>
 <div class="grid-row">
     <div class="column-two-thirds">
         <div class="course-contents">

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -147,6 +147,7 @@ dd > details, dd > details[open] {
 .course-basicinfo {
     margin-top: 30px;
     margin-bottom: 30px;
+    overflow: hidden;
 }
 .course-basicinfo dl dt {
     width: 25%;

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.2.3-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.3.0-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Shown in gif below:

* course 41 has full details so no link shown
* course 43 (only available on dev machine) has no "about" section so shows course link instead
* clicking link to UCAS grabs sessionId from UCAS site, builds link, and redirects user to the UCAS course page

![cap2](https://user-images.githubusercontent.com/19378/39435856-6054ed1a-4c94-11e8-9eac-dce2a0f5b807.gif)
