### PR TITLE
Temporarily hide "school-led"

### DIFF
--- a/src/ViewFormatters/CourseExtensions.cs
+++ b/src/ViewFormatters/CourseExtensions.cs
@@ -49,10 +49,11 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewFormatters
 
         public static string FormattedStudyInfo(this Course course)
         {
-            return string.Format("{0}, {1}, {2}",
+            return string.Format("{0}, {1}",
             course.Duration(),
-            course.IsUniversityLed() ? "university-led" : "school-led",
             string.Join(", ", course.GetStudyTypes()).ToLower());
+
+            // course.IsUniversityLed() ? "university-led" : "school-led",
         }
 
         public static IEnumerable<string> GetStudyTypes(this Course course)


### PR DESCRIPTION
We aren't correctly capturing whether a course is university or school led. For the time being, hide this text as it's not correct.

## Before
![screen shot 2018-05-01 at 11 46 23](https://user-images.githubusercontent.com/319055/39470382-4fc05a74-4d35-11e8-916a-d9a32c0670a0.png)

## After
![screen shot 2018-05-01 at 11 46 10](https://user-images.githubusercontent.com/319055/39470383-4fd64dd4-4d35-11e8-848c-5a37d6f45cc3.png)
