### PR TITLE
Bump elements to fix details element in Firefox

### DIFF
--- a/src/wwwroot/css/govuk-elements-styles.css
+++ b/src/wwwroot/css/govuk-elements-styles.css
@@ -1057,16 +1057,44 @@ details {
     color: #005ea5;
     cursor: pointer;
     position: relative;
-    margin-bottom: 0.26316em; }
-    details summary:hover {
-      color: #2b8cc4; }
-    details summary:focus {
-      outline: 3px solid #ffbf47; }
+    margin-bottom: 0.26316em;
+    padding-left: 25px; }
+  details summary:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    -webkit-clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+    clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+    border-width: 7px 0 7px 12.124px;
+    border-left-color: inherit; }
+  details summary:hover {
+    color: #2b8cc4; }
+  details summary:focus {
+    outline: 3px solid #ffbf47; }
+  details summary::-webkit-details-marker {
+    display: none; }
+  details[open] > summary:before {
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    -webkit-clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+    clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+    border-width: 12.124px 7px 0 7px;
+    border-top-color: inherit; }
   details .summary {
     text-decoration: underline; }
   details .arrow {
-    margin-right: .35em;
-    font-style: normal; }
+    display: none; }
 
 .panel {
   -webkit-box-sizing: border-box;
@@ -1625,8 +1653,3 @@ input[type=number] {
   color: #fff;
   background: #28a197;
   text-align: center; }
-
-@-moz-document regexp('.*') {
-  details summary:not([tabindex]) {
-    display: list-item;
-    display: revert; } }


### PR DESCRIPTION
### Context
https://github.com/alphagov/govuk_elements/commit/7ab22c24f06abed8d2edfb
5db72f6b50c4d0db38#diff-933e042aa8c02e66a821c8f4d8f00636

Details element on Firebox

### Changes proposed in this pull request
Copy across CSS from above commit

### Guidance to review
http://localhost:5000/course/70?l=2&subjects=2&funding=14&pgce=False&qts=False&fulltime=False&parttime=False

# Before
![screen shot 2018-07-06 at 09 53 43](https://user-images.githubusercontent.com/3071606/42369686-9d53329c-8102-11e8-941c-9da9b67e7605.png)

# After
![screen shot 2018-07-06 at 09 53 39](https://user-images.githubusercontent.com/3071606/42369696-a572a764-8102-11e8-8d62-58732be65a77.png)

