### PR TITLE
Remove search params from course details url

### DIFF
--- a/src/Assets/Javascript/back-link.js
+++ b/src/Assets/Javascript/back-link.js
@@ -1,0 +1,26 @@
+function BackLink ($module) {
+  this.$module = $module
+}
+
+BackLink.prototype.init = function () {
+  var $module = this.$module
+
+  if (!$module) {
+    return
+  }
+
+  window.addEventListener('load', function () {
+    var $isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;
+
+    if ($isInternalReferrer) {
+      var $link = document.createElement("a");
+      $link.setAttribute("href", "javascript:history.back()");
+      $link.setAttribute("class", "govuk-back-link")
+      $link.textContent = "Back to search results";
+
+      $module.appendChild($link);
+    }
+  })
+}
+
+export default BackLink

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -1,4 +1,5 @@
 import { initAll } from 'govuk-frontend';
+import BackLink from './Javascript/back-link';
 import './Javascript/cookie-bar.js';
 import './Javascript/accordion.js';
 import './Javascript/toggle.js';
@@ -6,6 +7,9 @@ import './Javascript/typeahead.jquery.js';
 import './Styles/site.scss';
 
 initAll();
+
+var $backLink = document.querySelector('[data-module="back-link"]')
+new BackLink($backLink).init()
 
 if (!!$) {
   $(document).ready(function () {

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -5,7 +5,7 @@
     var showMinimal = !Model.HasSection("about this training programme");
 }
 
-<div id="backLinkWrapper"></div>
+<div data-module="back-link"></div>
 
 <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
@@ -334,14 +334,3 @@
         </div>
     </div>
 </main>
-
-<script>
-    var isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;
-    if (isInternalReferrer) {
-        var backLink = document.createElement("a");
-        backLink.setAttribute("href", "javascript:history.back()");
-        backLink.setAttribute("class", "govuk-back-link")
-        backLink.textContent = "Back to search results";
-        document.getElementById("backLinkWrapper").appendChild(backLink);
-    }
-</script>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -5,11 +5,8 @@
     var showMinimal = !Model.HasSection("about this training programme");
 }
 
-@Html.Partial("Back", new BackLinkViewModel
-{
-    Href = Url.Action("Index", "Results", Model.FilterModel.ToRouteValues()),
-    Title = "Back to search results"
-})
+<div id="backLinkWrapper"></div>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -337,3 +334,14 @@
         </div>
     </div>
 </main>
+
+<script>
+    var isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;
+    if (isInternalReferrer) {
+        var backLink = document.createElement("a");
+        backLink.setAttribute("href", "javascript:history.back()");
+        backLink.setAttribute("class", "govuk-back-link")
+        backLink.textContent = "Back to search results";
+        document.getElementById("backLinkWrapper").appendChild(backLink);
+    }
+</script>

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -13,7 +13,7 @@
         var subjects = @item.CourseSubjects.Select(courseSubject => courseSubject.Subject.Name).ToArray();
         <li>
             <h3 class="govuk-heading-m">
-                <a href='@Url.Action("Index", "Course", RoutingUtil.Combine(Model.FilterModel.ToRouteValues(), new {courseId = item.Id}))' class="link">@item.Name at @item.Provider.Name</a>
+                <a href='@Url.Action("Index", "Course", new {courseId = item.Id})' class="link">@item.Name at @item.Provider.Name</a>
             </h3>
             <dl class="govuk-list--description">
                 @if (item.ProviderLocation != null) {


### PR DESCRIPTION
### Context
The course detail pages are pages in their own right and can be shared without the search params in the URL

### Changes proposed in this pull request
- Remove search result params
- Generate a back link with JS if the referrer is from the same domain i.e. the search results page

### Guidance to review

# From the results page
<img width="1392" alt="screen shot 2018-08-10 at 14 14 17" src="https://user-images.githubusercontent.com/3071606/43960255-63ded45e-9ca9-11e8-90c2-7294bffaacd9.png">

# Cold entry i.e. direct traffic / cold entry
<img width="1392" alt="screen shot 2018-08-10 at 14 14 14" src="https://user-images.githubusercontent.com/3071606/43960259-68131864-9ca9-11e8-9cd6-a005c3f343c2.png">


