### PR TITLE
Tidy up course meta data on mobile

### DIFF
--- a/src/Assets/Styles/components/_cookie-banner.scss
+++ b/src/Assets/Styles/components/_cookie-banner.scss
@@ -6,9 +6,7 @@
   width: 100%;
 
   padding-top: govuk-spacing(3);
-  padding-right: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
-  padding-left: govuk-spacing(3);
   background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
 }
 

--- a/src/Assets/Styles/patterns/_definition-list.scss
+++ b/src/Assets/Styles/patterns/_definition-list.scss
@@ -15,11 +15,12 @@
 
 %govuk-list--description > dd {
   @include govuk-font($size: 19, $weight: normal);
+  margin: 0 0 10px 0;
   vertical-align: top;
-  margin: 0;
 
   @include mq ($from: desktop) {
     float: left;
+    margin: 0;
     width: 66.66%;
   }
 

--- a/src/Assets/Styles/patterns/_definition-list.scss
+++ b/src/Assets/Styles/patterns/_definition-list.scss
@@ -15,7 +15,7 @@
 
 %govuk-list--description > dd {
   @include govuk-font($size: 19, $weight: normal);
-  margin: 0 0 10px 0;
+  margin: 0 0 govuk-spacing(2) 0;
   vertical-align: top;
 
   @include mq ($from: desktop) {

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -103,7 +103,8 @@
                         }
                         @if (Model.HasSection("entry requirements"))
                         {
-                            <li><a href="#section-entry">Requirements</a></li>                        }
+                            <li><a href="#section-entry">Requirements</a></li>
+                        }
                         @if (Model.HasSection("about placement schools"))
                         {
                             <li><a href="#section-schools">Placement schools</a></li>

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -22,10 +22,10 @@
                 <dl class="govuk-list--description">
                     @if (Model.Course.ProviderLocation != null)
                     {
-                        <dt><span class="govuk-list--description__label">Location</span></dt>
+                        <dt class="govuk-list--description__label">Location</dt>
                         <dd>@Model.Course.ProviderLocation.Address</dd>
                     }
-                    <dt><span class="govuk-list--description__label">Qualification</span></dt>
+                    <dt class="govuk-list--description__label">Qualification</dt>
                     <dd>
                         @if (Model.Course.IncludesPgce != IncludesPgce.No)
                         {
@@ -56,21 +56,21 @@
                     </dd>
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FundingOptions())) {
-                        <dt><span class="govuk-list--description__label">Financial support</span></dt>
+                        <dt class="govuk-list--description__label">Financial support</dt>
                         <dd>@Model.Course.FundingOptions()</dd>
                     }
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedStudyInfo())) {
-                        <dt><span class="govuk-list--description__label">Study type and duration</span></dt>
+                        <dt class="govuk-list--description__label">Study type and duration</dt>
                         <dd>@Model.Course.FormattedStudyInfo()</dd>
                     }
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedEarliestApplicationDate())) {
-                        <dt><span class="govuk-list--description__label">Date you can apply from</span></dt>
+                        <dt class="govuk-list--description__label">Date you can apply from</dt>
                         <dd>@Model.Course.FormattedEarliestApplicationDate()</dd>
                     }
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedStartDate())) {
-                        <dt><span class="govuk-list--description__label">Date course starts</span></dt>
+                        <dt class="govuk-list--description__label">Date course starts</dt>
                         <dd>@Model.Course.FormattedStartDate()</dd>
                     }
                 </dl>
@@ -103,8 +103,7 @@
                         }
                         @if (Model.HasSection("entry requirements"))
                         {
-                            <li><a href="#section-entry">Requirements</a></li>
-                        }
+                            <li><a href="#section-entry">Requirements</a></li>                        }
                         @if (Model.HasSection("about placement schools"))
                         {
                             <li><a href="#section-schools">Placement schools</a></li>
@@ -245,7 +244,7 @@
                         <dl class="govuk-list--description" role="contentinfo">
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Email))
                             {
-                                <dt class="bold"><span class="govuk-list--description__label">Email</span></dt>
+                                <dt class="govuk-list--description__label">Email</dt>
                                 <dd>
                                     <a href="mailto:@Model.Course.ContactDetails.Email"
                                     title="Send email to course contact"
@@ -257,17 +256,17 @@
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Phone))
                             {
-                                <dt class="bold"><span class="govuk-list--description__label">Telephone</span></dt>
+                                <dt class="govuk-list--description__label">Telephone</dt>
                                 <dd>@Model.Course.ContactDetails.Phone</dd>
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Fax))
                             {
-                                <dt class="bold"><span class="govuk-list--description__label">Fax</span></dt>
+                                <dt class="govuk-list--description__label">Fax</dt>
                                 <dd>@Model.Course.ContactDetails.Fax</dd>
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Website))
                             {
-                                <dt class="bold"><span class="govuk-list--description__label">Website</span></dt>
+                                <dt class="govuk-list--description__label">Website</dt>
                                 <dd>
                                     <a href="@Model.Course.ContactDetails.Website"
                                     title="Go to course website"
@@ -279,7 +278,7 @@
                             }
                             @if (Model.HasAddress())
                             {
-                                <dt class="bold"><span class="govuk-list--description__label">Address</span></dt>
+                                <dt class="govuk-list--description__label">Address</dt>
                                 <dd>
                                     @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Address))
                                     {

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -22,10 +22,10 @@
                 <dl class="govuk-list--description">
                     @if (Model.Course.ProviderLocation != null)
                     {
-                        <dt>Location</dt>
+                        <dt><span class="govuk-list--description__label">Location</span></dt>
                         <dd>@Model.Course.ProviderLocation.Address</dd>
                     }
-                    <dt>Qualification</dt>
+                    <dt><span class="govuk-list--description__label">Qualification</span></dt>
                     <dd>
                         @if (Model.Course.IncludesPgce != IncludesPgce.No)
                         {
@@ -56,21 +56,21 @@
                     </dd>
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FundingOptions())) {
-                        <dt>Financial support</dt>
+                        <dt><span class="govuk-list--description__label">Financial support</span></dt>
                         <dd>@Model.Course.FundingOptions()</dd>
                     }
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedStudyInfo())) {
-                        <dt>Study type and duration</dt>
+                        <dt><span class="govuk-list--description__label">Study type and duration</span></dt>
                         <dd>@Model.Course.FormattedStudyInfo()</dd>
                     }
 
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedEarliestApplicationDate())) {
-                        <dt>Date you can apply from</dt>
+                        <dt><span class="govuk-list--description__label">Date you can apply from</span></dt>
                         <dd>@Model.Course.FormattedEarliestApplicationDate()</dd>
                     }
                     @if (!string.IsNullOrEmpty(@Model.Course.FormattedStartDate())) {
-                        <dt>Date course starts</dt>
+                        <dt><span class="govuk-list--description__label">Date course starts</span></dt>
                         <dd>@Model.Course.FormattedStartDate()</dd>
                     }
                 </dl>
@@ -245,7 +245,7 @@
                         <dl class="govuk-list--description" role="contentinfo">
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Email))
                             {
-                                <dt class="bold">Email</dt>
+                                <dt class="bold"><span class="govuk-list--description__label">Email</span></dt>
                                 <dd>
                                     <a href="mailto:@Model.Course.ContactDetails.Email"
                                     title="Send email to course contact"
@@ -257,17 +257,17 @@
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Phone))
                             {
-                                <dt class="bold">Telephone</dt>
+                                <dt class="bold"><span class="govuk-list--description__label">Telephone</span></dt>
                                 <dd>@Model.Course.ContactDetails.Phone</dd>
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Fax))
                             {
-                                <dt class="bold">Fax</dt>
+                                <dt class="bold"><span class="govuk-list--description__label">Fax</span></dt>
                                 <dd>@Model.Course.ContactDetails.Fax</dd>
                             }
                             @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Website))
                             {
-                                <dt class="bold">Website</dt>
+                                <dt class="bold"><span class="govuk-list--description__label">Website</span></dt>
                                 <dd>
                                     <a href="@Model.Course.ContactDetails.Website"
                                     title="Go to course website"
@@ -279,7 +279,7 @@
                             }
                             @if (Model.HasAddress())
                             {
-                                <dt class="bold">Address</dt>
+                                <dt class="bold"><span class="govuk-list--description__label">Address</span></dt>
                                 <dd>
                                     @if (!String.IsNullOrWhiteSpace(Model.Course.ContactDetails.Address))
                                     {


### PR DESCRIPTION
### Context
https://trello.com/c/Ng44W5dv/88-clearer-metadata-mobile-styling-on-course-details-pages

### Changes proposed in this pull request
- Add semicolon
- Add margin-bottom for mobile

### Guidance to review
Any course page on mobile

# After
![localhost_5000_course_0_l 2 subjects 2 funding 15 pgce false qts false fulltime false parttime false iphone 6_7_8 1](https://user-images.githubusercontent.com/3071606/44036728-6be73534-9f0a-11e8-9d33-16611a901bb7.png)

