### PR TITLE
use (case insensitive) course codes in S+C URLs

### DIFF
--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -20,10 +20,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             _api = api;
         }
 
-        [HttpGet("course/{courseId:int}", Name = "Course")]
-        public IActionResult Index(int courseId, ResultsFilter filter)
+        [HttpGet("course/{courseCode:string}", Name = "Course")]
+        public IActionResult Index(string courseCode, ResultsFilter filter)
         {
-            var course = _api.GetCourse(courseId);
+            var course = _api.GetCourse(courseCode);
             var feeCaps = _api.GetFeeCaps();
 
             var latestFeeCaps = feeCaps.OrderByDescending(x => x.EndYear).FirstOrDefault();
@@ -37,5 +37,13 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             return View(viewModel);
         }
+        [HttpGet("course/{courseCode:string}/ucas-redirect", Name = "RedirectToUcasCourse")]
+        public RedirectResult RedirectToUcasCourse(string courseCode)
+        {
+            var url = _api.GetUcasCourseUrl(courseCode);
+
+            return new RedirectResult(url);
+        }
+
     }
 }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -37,13 +37,5 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             return View(viewModel);
         }
-        [HttpGet("course/{providerCode:string}/{courseCode:string}/ucas-redirect", Name = "RedirectToUcasCourse")]
-        public RedirectResult RedirectToUcasCourse(string providerCode, string courseCode)
-        {
-            var url = _api.GetUcasCourseUrl(providerCode, courseCode);
-
-            return new RedirectResult(url);
-        }
-
     }
 }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -20,10 +20,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             _api = api;
         }
 
-        [HttpGet("course/{courseCode:string}", Name = "Course")]
-        public IActionResult Index(string courseCode, ResultsFilter filter)
+        [HttpGet("course/{providerCode:string}/{courseCode:string}", Name = "Course")]
+        public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter)
         {
-            var course = _api.GetCourse(courseCode);
+            var course = _api.GetCourse(providerCode, courseCode);
             var feeCaps = _api.GetFeeCaps();
 
             var latestFeeCaps = feeCaps.OrderByDescending(x => x.EndYear).FirstOrDefault();
@@ -37,10 +37,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             return View(viewModel);
         }
-        [HttpGet("course/{courseCode:string}/ucas-redirect", Name = "RedirectToUcasCourse")]
-        public RedirectResult RedirectToUcasCourse(string courseCode)
+        [HttpGet("course/{providerCode:string}/{courseCode:string}/ucas-redirect", Name = "RedirectToUcasCourse")]
+        public RedirectResult RedirectToUcasCourse(string providerCode, string courseCode)
         {
-            var url = _api.GetUcasCourseUrl(courseCode);
+            var url = _api.GetUcasCourseUrl(providerCode, courseCode);
 
             return new RedirectResult(url);
         }

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.4.0-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.5.0-beta" />
   </ItemGroup>
   <Target Name="Webpack" Condition="'$(Configuration)'=='Release'" BeforeTargets="AfterBuild">
     <Exec Command="npm install" />

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.5.0-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.6.0-beta" />
   </ItemGroup>
   <Target Name="Webpack" Condition="'$(Configuration)'=='Release'" BeforeTargets="AfterBuild">
     <Exec Command="npm install" />

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.4.0-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.5.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.5.0-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.6.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -1,0 +1,81 @@
+
+
+using System;
+using System.Collections.Generic;
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI.Controllers;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
+{
+    [TestFixture]
+    public class CourseControllerTests
+    {
+        private Mock<ISearchAndCompareApi> mockApi;
+        private CourseController sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mockApi = new Mock<ISearchAndCompareApi>();
+            sut = new CourseController(mockApi.Object);
+        }
+
+        [Test]
+        public void Index_CallsApiCorrectly()
+        {
+            mockApi.Setup(x => x.GetCourse("1AB")).Returns(GetSimpleCourse()).Verifiable();
+            mockApi.Setup(x => x.GetFeeCaps()).Returns(GetFeeCaps()).Verifiable();
+
+            var actionResult = sut.Index("1AB", new Filters.ResultsFilter());
+
+            Assert.That(actionResult is ViewResult);
+            Assert.That((actionResult as ViewResult).Model is CourseViewModel);
+
+            var courseViewModel = (actionResult as ViewResult).Model as CourseViewModel;
+
+            Assert.AreEqual("My course", courseViewModel.Course.Name);
+            Assert.AreEqual(200, courseViewModel.Finance.FeeCaps.InternationalFees);
+            mockApi.VerifyAll();
+        }
+
+        [Test]
+        public void RedirectToUcasCourse_CallsApiCorrectly()
+        {
+            mockApi.Setup(x => x.GetUcasCourseUrl("1AB")).Returns("http://ucas.com").Verifiable();
+
+            var redirectResult = sut.RedirectToUcasCourse("1AB");
+
+            Assert.IsFalse(redirectResult.Permanent);
+            Assert.AreEqual("http://ucas.com", redirectResult.Url);
+            mockApi.VerifyAll();
+        }
+
+        private List<FeeCaps> GetFeeCaps()
+        {
+            return new List<FeeCaps>
+            {
+                new FeeCaps
+                {
+                    EndYear = 2000,
+                    UkFees = 100,
+                    EuFees = 100,
+                    InternationalFees = 200
+                }
+            };
+        }
+
+        private Course GetSimpleCourse()
+        {
+            return new Course
+            {
+                Name = "My course",
+                ProgrammeCode = "1AB"
+            };
+        }
+    }
+}

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -42,19 +42,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             Assert.AreEqual(200, courseViewModel.Finance.FeeCaps.InternationalFees);
             mockApi.VerifyAll();
         }
-
-        [Test]
-        public void RedirectToUcasCourse_CallsApiCorrectly()
-        {
-            mockApi.Setup(x => x.GetUcasCourseUrl("XYZ", "1AB")).Returns("http://ucas.com").Verifiable();
-
-            var redirectResult = sut.RedirectToUcasCourse("XYZ", "1AB");
-
-            Assert.IsFalse(redirectResult.Permanent);
-            Assert.AreEqual("http://ucas.com", redirectResult.Url);
-            mockApi.VerifyAll();
-        }
-
+        
         private List<FeeCaps> GetFeeCaps()
         {
             return new List<FeeCaps>

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -28,10 +28,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
         [Test]
         public void Index_CallsApiCorrectly()
         {
-            mockApi.Setup(x => x.GetCourse("1AB")).Returns(GetSimpleCourse()).Verifiable();
+            mockApi.Setup(x => x.GetCourse("XYZ", "1AB")).Returns(GetSimpleCourse()).Verifiable();
             mockApi.Setup(x => x.GetFeeCaps()).Returns(GetFeeCaps()).Verifiable();
 
-            var actionResult = sut.Index("1AB", new Filters.ResultsFilter());
+            var actionResult = sut.Index("XYZ", "1AB", new Filters.ResultsFilter());
 
             Assert.That(actionResult is ViewResult);
             Assert.That((actionResult as ViewResult).Model is CourseViewModel);
@@ -46,9 +46,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
         [Test]
         public void RedirectToUcasCourse_CallsApiCorrectly()
         {
-            mockApi.Setup(x => x.GetUcasCourseUrl("1AB")).Returns("http://ucas.com").Verifiable();
+            mockApi.Setup(x => x.GetUcasCourseUrl("XYZ", "1AB")).Returns("http://ucas.com").Verifiable();
 
-            var redirectResult = sut.RedirectToUcasCourse("1AB");
+            var redirectResult = sut.RedirectToUcasCourse("XYZ", "1AB");
 
             Assert.IsFalse(redirectResult.Permanent);
             Assert.AreEqual("http://ucas.com", redirectResult.Url);


### PR DESCRIPTION
### Context

https://trello.com/c/NyS5Xcy3/51-persistent-urls-in-search-and-compare-using-course-code

### Changes proposed in this pull request

Use v 0.5.0 of api client

Add some tests

### Guidance to review

See the tests and reference corresponding API pull request: https://github.com/DFE-Digital/search-and-compare-api/pull/33
