### PR TITLE
fix hasSalary logic syntax

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/bin/Debug/netcoreapp2.0/SearchAndCompareUi.dll",
+            "program": "${workspaceFolder}/src/bin/Debug/netcoreapp2.1/SearchAndCompareUi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src",
             "stopAtEntry": false,

--- a/src/ViewComponents/SuggestedSearch.cs
+++ b/src/ViewComponents/SuggestedSearch.cs
@@ -26,7 +26,10 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewComponents
         {
             var originalTotal = original.Courses.TotalCount;
 
-            var hasSalary = !(original.FilterModel.SelectedFunding.HasValue && original.FilterModel.SelectedFunding.Value == FundingOption.All) && original.FilterModel.SelectedFunding.Value.HasFlag(FundingOption.Salary);
+            var hasSalary = 
+                original.FilterModel.SelectedFunding.HasValue && 
+                original.FilterModel.SelectedFunding.Value != FundingOption.All && 
+                original.FilterModel.SelectedFunding.Value.HasFlag(FundingOption.Salary);
 
             var resultsFilters = GetSuggestedSearchesResultsFiltersForAllFunding(original);
 

--- a/tests/Unit.Tests/ViewComponents/SuggestedSearchTests.cs
+++ b/tests/Unit.Tests/ViewComponents/SuggestedSearchTests.cs
@@ -1,0 +1,40 @@
+﻿using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Data;
+using GovUk.Education.SearchAndCompare.Domain.Filters;
+using GovUk.Education.SearchAndCompare.Domain.Lists;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.ViewComponents;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using GovUk.Education.SearchAndCompare.ViewModels;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Moq;
+using NUnit.Framework;
+
+namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewComponents
+{
+    [TestFixture]
+    public class SuggestedSearchTests
+    {
+        [Test]
+        public void EmptyDoesntThrow()
+        {
+            var empty = new ResultsViewModel
+            {
+                Map = new MapViewModel(),
+                Courses = new PaginatedList<Course>(),
+                Subjects = new FilteredList<Subject>(),
+                FilterModel = new ResultsFilter()
+            };
+
+            var mockApi = new Mock<ISearchAndCompareApi>();
+            mockApi.Setup(x => x.GetCoursesTotalCount(It.IsAny<QueryFilter>())).Returns(new TotalCountResult());
+
+            var res = new SuggestedSearch(mockApi.Object)
+                .InvokeAsync(empty, 100).Result;
+
+            Assert.That(res is ViewViewComponentResult);
+        }
+    }
+
+}


### PR DESCRIPTION
### Context

https://trello.com/c/SzRZJePg/195-unexpected-404-when-search-returns-no-results#

### Changes proposed in this pull request

There was a piece of logic that seemed to have a null check inverted.

### Guidance to review

n/a

