### PR TITLE
Refactor and fix styling of subjects list in results filter

### DIFF
--- a/src/Views/Shared/Filters/Subject.cshtml
+++ b/src/Views/Shared/Filters/Subject.cshtml
@@ -1,20 +1,16 @@
 @model ResultsViewModel
 
-@* https://www.gov.uk/search *@
-
 <div class="filter-form">
-    <h3 class="govuk-heading-s filter-form__title">
-        Subjects<span class="govuk-visually-hidden">:</span>
-    </h3>
-    @if (Model.Subjects.Items.Count() > 5) {
-        <text>@Html.Raw(string.Join(",<br>", Model.Subjects.Items.OrderBy(x => x.Name).Take(4).Select(x => x.Name))),<br>and @(Model.Subjects.Items.Count() - 4) more&hellip;</text>
-    } else {
-    <ul class="filter-form__value--list">
-        @foreach (var item in Model.Subjects.Items.OrderBy(x => x.Name).Select(x=>x.Name)) {
-        <li>@item</li>
-        }
-    </ul>
+  <h3 class="govuk-heading-s filter-form__title">
+    Subjects<span class="govuk-visually-hidden">:</span>
+  </h3>
+  <ul class="filter-form__value--list">
+    @foreach (var item in Model.Subjects.Items.OrderBy(x => x.Name).Take(4).Select(x => x.Name)) {
+      <li>@item</li>
     }
-    <a href='@Url.Action("Subject", "Filter", Model.FilterModel.ToRouteValues())' class="govuk-link">Change subjects</a>
+    @if (Model.Subjects.Items.Count() > 4) {
+      <li>and @(Model.Subjects.Items.Count() - 4) more&hellip;</li>
+    }
+  </ul>
+  <a href='@Url.Action("Subject", "Filter", Model.FilterModel.ToRouteValues())' class="govuk-link">Change subjects</a>
 </div>
-


### PR DESCRIPTION
### Context
When selecting more than one subject the styling is broken

### Changes proposed in this pull request
Refactor subject list

### Guidance to review
`http://localhost:5000/results?subjects=34&funding=15&pgce=False&qts=False&fulltime=False&parttime=False`

# Before
<img width="328" alt="screen shot 2018-08-28 at 15 16 57" src="https://user-images.githubusercontent.com/3071606/44731815-e74dde80-aadb-11e8-8e56-0a61292d9dc2.png">

# After
![screen shot 2018-08-28 at 16 02 27](https://user-images.githubusercontent.com/3071606/44731890-13695f80-aadc-11e8-92fc-ef1ca11e19c5.png)
![screen shot 2018-08-28 at 16 02 10](https://user-images.githubusercontent.com/3071606/44731891-13695f80-aadc-11e8-8d22-54016d087599.png)
