### PR TITLE
Missing course should cause 404 not 500 [wip]

### DIFF
--- a/SearchAndCompareUI.sln
+++ b/SearchAndCompareUI.sln
@@ -6,7 +6,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUi.Shared",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUi", "src\SearchAndCompareUi.csproj", "{83AA01DC-6869-4403-91C3-FE45F9C6B946}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUI.Tests", "tests\SearchAndCompareUI.Tests.csproj", "{E6BC67D7-901E-49B6-909E-5C3C699D6194}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareUI.Tests", "tests\SearchAndCompareUI.Tests.csproj", "{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B312634F-9CFE-4A03-B2E9-9A4F4573A4BA}"
 	ProjectSection(SolutionItems) = preProject
@@ -31,18 +31,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.Build.0 = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.Build.0 = Debug|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.Build.0 = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.ActiveCfg = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.Build.0 = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.ActiveCfg = Release|Any CPU
-		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.Build.0 = Release|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -55,6 +43,30 @@ Global
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x64.Build.0 = Release|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.ActiveCfg = Release|Any CPU
 		{E6BC67D7-901E-49B6-909E-5C3C699D6194}.Release|x86.Build.0 = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x64.Build.0 = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Debug|x86.Build.0 = Debug|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.ActiveCfg = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x64.Build.0 = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.ActiveCfg = Release|Any CPU
+		{83AA01DC-6869-4403-91C3-FE45F9C6B946}.Release|x86.Build.0 = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|x64.Build.0 = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0696DC3-29F7-4FBB-8E19-9F29F50C530C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -1,22 +1,31 @@
 using GovUk.Education.SearchAndCompare.Domain.Client;
-using GovUk.Education.SearchAndCompare.UI.ViewModels;
-using GovUk.Education.SearchAndCompare.UI.Services;
-using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
-using GovUk.Education.SearchAndCompare.UI.ActionFilters;
-using System.Linq;
 using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.SearchAndCompare.UI.Controllers
 {
 
-    //[Authorize]
     public class CourseController : CommonAttributesControllerBase
     {
+        private readonly ISearchAndCompareApi _api;
+
+        public CourseController(ISearchAndCompareApi api)
+        {
+            _api = api;
+        }
+
         [HttpGet("course/{providerCode}/{courseCode}", Name = "Course")]
         public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter)
         {
-            return View(new CourseViewModel {
+            var course = _api.GetCourse(providerCode, courseCode);
+            if (course == null)
+            {
+                return NotFound();
+            }
+
+            return View(new CourseViewModel
+            {
                 CourseCode = courseCode,
                 ProviderCode = providerCode
             });


### PR DESCRIPTION
### Context

Linking to a missing course was causing a 500 null ref.
Can't 404 from within the view component so have to do a duplicate check. :-(

### Changes proposed in this pull request

Check for course existence and 404 if missing
Before trying to render page.

### Guidance to review

