### PR TITLE
fix hasSalary null reference exceptions, part 2

### DIFF
--- a/src/ViewComponents/SuggestedSearch.cs
+++ b/src/ViewComponents/SuggestedSearch.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewComponents
                 salaryResults = GetResults(salaryResultsFilters, originalTotal, salaryResultsFilters.Count());
             }
 
-            var result = new SuggestedSearchesViewModel { OriginalResults = original};
+            var result = new SuggestedSearchesViewModel { OriginalResults = original, HasSalary = hasSalary };
             var salaryResult = salaryResults.FirstOrDefault();
             if (salaryResult != null) {
                 result.SuggestedSearches = GetResults(resultsFilters, originalTotal, maxResult - salaryResults.Count() );

--- a/src/ViewModels/SuggestedSearchesViewModel.cs
+++ b/src/ViewModels/SuggestedSearchesViewModel.cs
@@ -8,5 +8,6 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewModels
     {
         public List<SuggestedSearchViewModel> SuggestedSearches { get; set; }
         public ResultsViewModel OriginalResults { get; set; }
+        public bool HasSalary { get; internal set; }
     }
 }

--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -8,7 +8,7 @@
       @foreach (var item in Model.SuggestedSearches)
       {
         var courseText = " course" + (item.TotalCount == 1 ? "" : "s");
-        var areaText = item.ResultsFilter?.RadiusOption?.rad != null  item.ResultsFilter?.RadiusOption?.rad != null ?
+        var areaText = item.ResultsFilter?.RadiusOption?.rad != null && item.ResultsFilter?.RadiusOption?.rad != null ?
           " within " + item.ResultsFilter.rad + " miles of " + item.ResultsFilter.loc :
           (
             Model.HasSalary ?

--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -3,17 +3,15 @@
 <h3 class="govuk-heading-m">Suggested searches</h3>
 
 @if(Model.SuggestedSearches.Any()) {
-    var hasSalary = !(Model.OriginalResults.FilterModel.SelectedFunding.HasValue && Model.OriginalResults.FilterModel.SelectedFunding.Value == FundingOption.All) && Model.OriginalResults.FilterModel.SelectedFunding.Value.HasFlag(FundingOption.Salary);
-
     <p class="govuk-body">There are:</p>
     <ul class="govuk-list govuk-list--bullet">
       @foreach (var item in Model.SuggestedSearches)
       {
         var courseText = " course" + (item.TotalCount == 1 ? "" : "s");
-        var areaText = item.ResultsFilter.RadiusOption.HasValue ?
+        var areaText = item.ResultsFilter?.RadiusOption?.rad != null  item.ResultsFilter?.RadiusOption?.rad != null ?
           " within " + item.ResultsFilter.rad + " miles of " + item.ResultsFilter.loc :
           (
-            hasSalary ?
+            Model.HasSalary ?
               " with " + item.ResultsFilter.GetFundingTypes().First().ToLowerInvariant() + " available in England" :
               " across England" );
         var text = item.TotalCount + courseText + areaText;

--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -8,7 +8,7 @@
       @foreach (var item in Model.SuggestedSearches)
       {
         var courseText = " course" + (item.TotalCount == 1 ? "" : "s");
-        var areaText = item.ResultsFilter?.RadiusOption?.rad != null && item.ResultsFilter?.RadiusOption?.rad != null ?
+        var areaText = item.ResultsFilter?.rad != null && item.ResultsFilter?.loc != null ?
           " within " + item.ResultsFilter.rad + " miles of " + item.ResultsFilter.loc :
           (
             Model.HasSalary ?


### PR DESCRIPTION
### Context

Turns out there was some code duplication so the issue from this fix resurfaced:

https://github.com/DFE-Digital/search-and-compare-ui/pull/84


### Changes proposed in this pull request

Include hasSalary in the view model rather than evaluating the expression twice

### Guidance to review

n/a

