### PR TITLE
fix markdown link

### DIFF
--- a/shared/Utils/MarkdownFormatter.cs
+++ b/shared/Utils/MarkdownFormatter.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Utils
 {
     public class MarkdownFormatter
     {
-        private static readonly Regex linkRegex = new Regex(@"\[ *([^\]\n]+) *\](?:\( *([^\)\s\n]+) *\))?", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex linkRegex = new Regex(@"\[ *([^\]\n]+) *\](?:\( *((?:[^\\\(\)\s\n]|\\\(|\\\)|\\\\)+) *\))?", RegexOptions.Compiled | RegexOptions.Multiline);
 		private static readonly Regex listItemRegex = new Regex(@"^\s*(?:-|\*|[0-9]+\.?)[\t\f\v ](.*)\n?", RegexOptions.Compiled | RegexOptions.Multiline);
 		private static readonly Regex listWrapperRegex = new Regex(@"<li>(?:<\/li>\s*<li>|(?!<\/li>).)*<\/li>", RegexOptions.Compiled );
 		private static readonly Regex paragraphRegex = new Regex(@"^\s*[^<].*$", RegexOptions.Compiled | RegexOptions.Multiline);
@@ -36,6 +36,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Utils
 
             res = linkRegex.Replace(res, new MatchEvaluator(match => {
                 var href = match.Groups.Count > 2 && !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value.Trim() : match.Groups[1].Value.Trim();
+                href.Replace("\\(", "(");         
+                href.Replace("\\)", ")");
+                href.Replace("\\\\", "\\");       
+                
                 return $"<a href=\"{href}\" class=\"govuk-link\">{match.Groups[1].Value.Trim()}</a>";
                 }));
 

--- a/shared/Utils/MarkdownFormatter.cs
+++ b/shared/Utils/MarkdownFormatter.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Utils
 {
     public class MarkdownFormatter
     {
-        private static readonly Regex linkRegex = new Regex(@"\[([^\s\]\n]+)[\t\f\v ]*([^\]\n]+)?\]", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex linkRegex = new Regex(@"\[ *([^\]\n]+) *\](?:\( *([^\)\s\n]+) *\))?", RegexOptions.Compiled | RegexOptions.Multiline);
 		private static readonly Regex listItemRegex = new Regex(@"^\s*(?:-|\*|[0-9]+\.?)[\t\f\v ](.*)\n?", RegexOptions.Compiled | RegexOptions.Multiline);
 		private static readonly Regex listWrapperRegex = new Regex(@"<li>(?:<\/li>\s*<li>|(?!<\/li>).)*<\/li>", RegexOptions.Compiled );
 		private static readonly Regex paragraphRegex = new Regex(@"^\s*[^<].*$", RegexOptions.Compiled | RegexOptions.Multiline);
@@ -35,8 +35,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Utils
             res = paragraphRegex.Replace(res, new MatchEvaluator(match => $"<p class=\"govuk-body\">{match.Groups[0].Value.Trim()}</p>"));
 
             res = linkRegex.Replace(res, new MatchEvaluator(match => {
-                var linkText = match.Groups.Count > 2 && !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value.Trim() : match.Groups[1].Value.Trim();
-                return $"<a href=\"{match.Groups[1].Value}\" class=\"govuk-link\">{linkText}</a>";
+                var href = match.Groups.Count > 2 && !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value.Trim() : match.Groups[1].Value.Trim();
+                return $"<a href=\"{href}\" class=\"govuk-link\">{match.Groups[1].Value.Trim()}</a>";
                 }));
 
             return new HtmlString(res.Trim());

--- a/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
+++ b/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
@@ -62,7 +62,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Utils
         [Test]
         public void PureLinkWithWhiteSpace()
         {
-            var markdown = "[www.example.com    ]";
+            var markdown = "[ www.example.com    ]";
             var expected = "<p class=\"govuk-body\"><a href=\"www.example.com\" class=\"govuk-link\">www.example.com</a></p>";
             Assert.That(GetHtml(markdown), Is.EqualTo(expected));
         }
@@ -70,7 +70,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Utils
         [Test]
         public void NamedLink()
         {
-            var markdown = "[www.example.com   Go to www.example.com  ]";
+            var markdown = "[Go to www.example.com](www.example.com)";
             var expected = "<p class=\"govuk-body\"><a href=\"www.example.com\" class=\"govuk-link\">Go to www.example.com</a></p>";
             Assert.That(GetHtml(markdown), Is.EqualTo(expected));
         }
@@ -78,19 +78,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Utils
         [Test]
         public void LinkInParagraph()
         {
-            var markdown = "Go to [www.example.com our website].\nYou'll like it there.";
+            var markdown = "Go to [our website](www.example.com).\nYou'll like it there.";
             var expected = "<p class=\"govuk-body\">Go to <a href=\"www.example.com\" class=\"govuk-link\">our website</a>.</p>\n<p class=\"govuk-body\">You'll like it there.</p>";
             Assert.That(GetHtml(markdown), Is.EqualTo(expected));
         }
-
-        [Test]
-        public void NotALink()
-        {
-            var markdown = "[ www.nosite.com]";
-            var expected = "<p class=\"govuk-body\">[ www.nosite.com]</p>";
-            Assert.That(GetHtml(markdown), Is.EqualTo(expected));
-        }
-
 
         [Test]
         public void NotALink2()

--- a/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
+++ b/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
@@ -82,6 +82,13 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Utils
             var expected = "<p class=\"govuk-body\">Go to <a href=\"www.example.com\" class=\"govuk-link\">our website</a>.</p>\n<p class=\"govuk-body\">You'll like it there.</p>";
             Assert.That(GetHtml(markdown), Is.EqualTo(expected));
         }
+        
+        public void LinkWithParenthesesInParentheses()
+        {
+            var markdown = "(Go to [Wikipedia](https://en.wikipedia.org/wiki/Brackets_\\(text_editor\\))).";
+            var expected = "<p class=\"govuk-body\">(Go to <a href=\"https://en.wikipedia.org/wiki/Brackets_(text_editor)\" class=\"govuk-link\">Wikipedia</a>.</p>";
+            Assert.That(GetHtml(markdown), Is.EqualTo(expected));
+        }
 
         [Test]
         public void NotALink2()


### PR DESCRIPTION
### Context

https://trello.com/c/x2N5gGtF/240-broken-markdown-rendering-of-brackets-around-link

### Changes proposed in this pull request

change regex to meet markdown spec

### Guidance to review

look at the tests rather than the regex if you prefer :)
