### PR TITLE
Don't send pii to google analytics

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -19,6 +19,16 @@
       ga('create', 'UA-112932657-1', 'auto');
       ga('set', 'transport', 'beacon');
       ga('set', 'anonymizeIp', true);
+
+      if (location.search) {
+        var search = location.search;
+        var params = ['lat', 'lng', 'loc', 'lq'];
+        for( i = 0; i < params.length; i++ ){
+          search = search.replace( new RegExp( '([?&])'+params[i]+'(=[^&]*)?&?', 'gi' ), '$1' );
+        }
+        ga('set', 'location', window.location.protocol + "//" + window.location.host + window.location.pathname + search)
+      }
+
       ga('send', 'pageview');
     </script>
   }


### PR DESCRIPTION
### Context
We shouldn't be sending PII(Personal Identity Information) to Google Analytics such as email, name, location

### Changes proposed in this pull request
Remove lat, long and address from search parameters before sending to GA

### Guidance to review
## Before 
<img width="606" alt="screen shot 2018-09-06 at 13 20 13" src="https://user-images.githubusercontent.com/3071606/45156995-b3f40980-b1d7-11e8-8d73-fbc7b9e516ab.png">

## After
<img width="608" alt="screen shot 2018-09-06 at 13 20 26" src="https://user-images.githubusercontent.com/3071606/45156997-b5253680-b1d7-11e8-8245-fbb4f0b1485c.png">