### PR TITLE
Fixed geocoder return null as it should return empty instance

### DIFF
--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
-using System.Web;
 using System.Threading.Tasks;
+using System.Web;
+using GovUk.Education.SearchAndCompare.Domain.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Linq;
-using System;
-using GovUk.Education.SearchAndCompare.Domain.Models;
-using System.Collections.Generic;
 
 namespace GovUk.Education.SearchAndCompare.UI.Services
 {
@@ -32,7 +32,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
 
                 dynamic json = JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync());
 
-                if ("OK" != (string)json.status)
+                if ("OK" != (string) json.status)
                 {
                     return null;
                 }
@@ -64,22 +64,22 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                 query["language"] = "en";
                 query["input"] = input;
                 query["components"] = "country:uk";
-                query["types"]="geocode";
+                query["types"] = "geocode";
 
                 var response = await client.GetAsync("https://maps.googleapis.com/maps/api/place/autocomplete/json?" + query.ToString());
 
                 dynamic json = JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync());
 
-                if ("OK" != (string)json.status)
+                var res = new List<string>();
+
+                if ("OK" == (string) json.status)
                 {
-                    return null;
+                    foreach (var prediction in json.predictions)
+                    {
+                        res.Add((string) prediction.description);
+                    }
                 }
 
-                var res = new List<string>();
-                foreach(var prediction in json.predictions)
-                {
-                    res.Add((string)prediction.description);
-                }
                 return res;
             }
         }
@@ -87,8 +87,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
         private static bool IsIndicativeOfUk(JToken addressComponent)
         {
             JArray types = (JArray) addressComponent["types"];
-            return types.Any(x => "country" == (string) x)
-                && (string) addressComponent["short_name"] == "GB";
+            return types.Any(x => "country" == (string) x) &&
+                (string) addressComponent["short_name"] == "GB";
         }
     }
 }

--- a/tests/Unit.Tests/Controllers/DynamicController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/DynamicController.Tests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI.Controllers;
+using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Services;
+using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
+{
+    [TestFixture]
+    public class DynamicControllerTests
+    {
+        [Test]
+        public async Task LocationSuggest_empty()
+        {
+            var query = "e15 1";
+            var mockApi = new Mock<ISearchAndCompareApi>();
+            var geocoderApi = new Mock<IGeocoder>();
+            geocoderApi.Setup(x => x.SuggestLocationsAsync(query))
+                .ReturnsAsync(new List<string>());
+            var controller = new DynamicController(mockApi.Object, geocoderApi.Object);
+
+            var res = await controller.LocationSuggest(query);
+            var jsonResult = res as JsonResult;
+            Assert.IsNotNull(jsonResult);
+
+            Assert.IsNotNull(jsonResult.Value);
+            var jsonResultValue = jsonResult.Value as List<string>;
+            Assert.IsNotNull(jsonResultValue);
+            CollectionAssert.IsEmpty(jsonResultValue);
+        }
+
+        [Test]
+        public async Task LocationSuggest()
+        {
+            var query = "e15 1";
+            var mockApi = new Mock<ISearchAndCompareApi>();
+            var geocoderApi = new Mock<IGeocoder>();
+            geocoderApi.Setup(x => x.SuggestLocationsAsync(query))
+                .ReturnsAsync(new List<string>() { query});
+            var controller = new DynamicController(mockApi.Object, geocoderApi.Object);
+
+            var res = await controller.LocationSuggest(query);
+            var jsonResult = res as JsonResult;
+            Assert.IsNotNull(jsonResult);
+
+            Assert.IsNotNull(jsonResult.Value);
+            var jsonResultValue = jsonResult.Value as List<string>;
+            Assert.IsNotNull(jsonResultValue);
+            CollectionAssert.IsNotEmpty(jsonResultValue);
+            Assert.AreEqual(query, jsonResultValue[0]);
+            Assert.AreEqual(1, jsonResultValue.Count);
+        }
+    }
+}


### PR DESCRIPTION
### Context
User type in postcode and it throws js errors

### Changes proposed in this pull request
Return empty instances instance of null, which was the cause of the error
### Guidance to review
Proposed
![geo js error fixed](https://user-images.githubusercontent.com/470137/45214059-57552500-b291-11e8-8988-cb9f4cefaaf0.gif)

Previously 
![geo js error](https://user-images.githubusercontent.com/470137/45214071-60de8d00-b291-11e8-9206-1351ca0a1fa5.gif)

