### PR TITLE
Accessibility tweaks

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -22,7 +22,7 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl" role="heading">
+            <h1 class="govuk-heading-xl">
                 @Model.Course.Name at @Model.Provider.Name
 
                 @if (!String.IsNullOrEmpty(Model.Course.AccreditingProvider?.Name))

--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -16,7 +16,7 @@
             @Html.Partial("Error", errors)
             <form action='@Url.Action("Funding", "Filter", Model.ToRouteValues())' method="POST">
                 <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-                    <legend role="heading" class="govuk-fieldset__legend govuk-fieldset__legend--xl">       
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">       
                         <h1 class="govuk-heading-xl">Financial support while you&nbsp;train</h1>
                     </legend>
                     <p class="govuk-body">

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -24,7 +24,7 @@
 
             <form action='@Url.Action(isInWizard ? "LocationWizard" : "Location", "Filter", Model.FilterModel.ToRouteValues())' method="POST">
                 <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-                    <legend role="heading" class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 class="govuk-fieldset__heading">Find courses by location or by training provider</h1>
                     </legend>
 

--- a/src/Views/Filter/Qualification.cshtml
+++ b/src/Views/Filter/Qualification.cshtml
@@ -15,7 +15,7 @@
         <div class="govuk-grid-column-two-thirds">
             <form action='@Url.Action("StudyType", "Filter", Model.ToRouteValues())' method="POST">
                 <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-                    <legend role="heading" class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 class="govuk-heading-xl">The qualification you’ll&nbsp;get</h1>
                     </legend>
 

--- a/src/Views/Filter/StudyType.cshtml
+++ b/src/Views/Filter/StudyType.cshtml
@@ -15,7 +15,7 @@
         <div class="govuk-grid-column-two-thirds">
             <form action='@Url.Action("StudyType", "Filter", Model.ToRouteValues())' method="POST">
                 <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-                    <legend role="heading">
+                    <legend>
                         <h1 class="govuk-heading-xl">Study type</h1>
                     </legend>
 

--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿<main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl" role="heading">
+            <h1 class="govuk-heading-xl">
                 Find postgraduate teacher training
             </h1>
             <p class="govuk-body-l">

--- a/src/Views/Results/Index.cshtml
+++ b/src/Views/Results/Index.cshtml
@@ -9,7 +9,7 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl" role="heading">
+      <h1 class="govuk-heading-xl">
         Teacher training courses
       </h1>
     </div>

--- a/src/Views/Shared/Display/Map.cshtml
+++ b/src/Views/Shared/Display/Map.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="search-results-header">
-    <div class="found-heading" role="heading">
+    <div class="found-heading">
         <p class="found-count">@mapModel.CourseGroups.Count() course locations found</p>
         <p class="new-search"><a href='@Url.Action("LocationWizard", "Filter")'>New search</a></p>
     </div>

--- a/src/Views/Shared/_Layout_base.cshtml
+++ b/src/Views/Shared/_Layout_base.cshtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 @RenderSection("topOfPage", required: false)
-<html lang="@(ViewData[" htmlLang "] ?? "en ")" class="govuk-template ">
+<html lang="@(ViewData[" htmlLang "] ?? "en")" class="govuk-template">
   <head>
     <meta charset="utf-8" />
     <title>@(ViewBag.Title ?? "Welcome to GOV.UK")</title>


### PR DESCRIPTION
Remove trailing whitespace from lang. Our accessibility review flagged an invalid language code. Switching from "en " to "en".

Remove invalid aria heading role. From the accessibility review:

> On all assessed pages the ARIA role ‘heading’ is used without the necessary
> additional ‘aria-level’. It would be easier to remove the role from headings as
> its inherent to them.

We also don't need aria-role on the legend tags.