### PR TITLE
Optional basic auth protection for site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ See the [Search and Compare](https://github.com/DFE-Digital/search-and-compare) 
 ## Dotnet SDK
 You will need to have Version 2.1.300~2.1.302 of the dotnet SDK installed in order to build and run this. This is due to a bug in ASP.NET MVC Core which is using inconsistent package versions. [The bug](https://github.com/aspnet/Mvc/issues/7969) has a fix promised in .NET Core 2.1.3.  
 
+## Config
+
+### Pre-launch password
+
+Set environment variable / user secret "SITE_PASSWORD" to the chosen password,
+restart the app.
+
+Users will be prompted for a username/password, the username is ignored.
+
+When we are ready for launch clear/remove the environment variable and restart
+this microservice.
+
 ## Running
 Run
 

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>GovUk.Education.SearchAndCompare.UI</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="idunno.Authentication.Basic" Version="2.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Security.Claims;
+using System.Threading.Tasks;
+using idunno.Authentication.Basic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.SearchAndCompare.UI
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddBasicAuth(this IServiceCollection services, string sitePassword)
+        {
+            if (string.IsNullOrWhiteSpace(sitePassword))
+            {
+                return;
+            }
+
+            services.AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
+                .AddBasic(options =>
+                {
+                    options.Events = new BasicAuthenticationEvents
+                    {
+                        OnValidateCredentials = context =>
+                        {
+                            if (context.Password != sitePassword)
+                            {
+                                return Task.CompletedTask;
+                            }
+
+                            var claims = new[]
+                            {
+                                new Claim(
+                                    ClaimTypes.NameIdentifier,
+                                    context.Username,
+                                    ClaimValueTypes.String,
+                                    context.Options.ClaimsIssuer),
+                                new Claim(
+                                    ClaimTypes.Name,
+                                    context.Username,
+                                    ClaimValueTypes.String,
+                                    context.Options.ClaimsIssuer)
+                            };
+
+                            context.Principal = new ClaimsPrincipal(
+                                new ClaimsIdentity(claims, context.Scheme.Name));
+                            context.Success();
+
+                            return Task.CompletedTask;
+                        }
+                    };
+                    options.AllowInsecureProtocol = true; // only production has https
+                });
+        }
+    }
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -34,7 +34,6 @@ namespace GovUk.Education.SearchAndCompare.UI
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -42,7 +42,7 @@ namespace GovUk.Education.SearchAndCompare.UI
         {
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
 
-            if (PreLanuchMode)
+            if (PreLaunchMode)
             {
                 services.AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
                     .AddBasic(options =>
@@ -82,7 +82,7 @@ namespace GovUk.Education.SearchAndCompare.UI
             var sharedAssembly = typeof(CourseDetailsViewComponent).GetTypeInfo().Assembly;
             services.AddMvc(config =>
                 {
-                    if (PreLanuchMode)
+                    if (PreLaunchMode)
                     {
                         config.Filters.Add(new AuthorizeFilter(
                             new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()));
@@ -103,7 +103,7 @@ namespace GovUk.Education.SearchAndCompare.UI
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            if (PreLanuchMode)
+            if (PreLaunchMode)
             {
                 app.UseAuthentication();
             }
@@ -143,7 +143,7 @@ namespace GovUk.Education.SearchAndCompare.UI
             });
         }
 
-        private bool PreLanuchMode => !string.IsNullOrWhiteSpace(SitePassword);
+        private bool PreLaunchMode => !string.IsNullOrWhiteSpace(SitePassword);
 
         /// <summary>
         /// This will be set to prevent potential teachers seeing next year's course listings too early.


### PR DESCRIPTION
### Context

We want to be able to see & share next year's course listings before they are ready to be seen by candidates. This adds an optional password to protect the whole site. See the readme for usage.

### Changes proposed in this pull request

* Add a basic auth lib.
* Make it configurable based on password config.