### PR TITLE
Always use proper error pages

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -73,7 +73,6 @@ namespace GovUk.Education.SearchAndCompare.UI
 
             if (env.IsDevelopment())
             {
-                app.UseDeveloperExceptionPage();
                 app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions
                 {
                     HotModuleReplacement = true
@@ -89,9 +88,9 @@ namespace GovUk.Education.SearchAndCompare.UI
             }
             else
             {
-                app.UseStatusCodePagesWithRedirects("/error/{0}");
                 app.UseStaticFiles();
             }
+            app.UseStatusCodePagesWithRedirects("/error/{0}");
 
             app.AddContentLanguageHeaders("en");
 


### PR DESCRIPTION
I wasted around a day because of this difference in behaviour between development mode and production mode. It also meant the development site broken when everything had worked fine locally. It's also the reason I couldn't sleep this evening and ended up fixing this all at 3am. Let's just say I have strong feelings about this going in.

### Context
This is the reason I didn't do #111 first time round as part of #108.

### Changes proposed in this pull request
Get rid of special pages for developer mode. Developers have debuggers and don't need such things. None of our dev/staging sites use development mode.