### PR TITLE
Remove reference to open license in footer

### DIFF
--- a/src/Assets/Styles/site.scss
+++ b/src/Assets/Styles/site.scss
@@ -116,6 +116,10 @@ $govuk-global-styles: true;
   margin-top: govuk-spacing(2);
 }
 
+.govuk-footer__inline-list {
+  margin-bottom: 0;
+}
+
 .govuk-footer__content {
   @include govuk-font($size: 16, $line-height: 1.5);
   color: $govuk-text-colour;

--- a/src/Views/Shared/_Layout_base.cshtml
+++ b/src/Views/Shared/_Layout_base.cshtml
@@ -76,15 +76,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             @RenderSection("footerSupportLinks", required: true)
-            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7"
-              height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
           </div>
           <div class="govuk-footer__meta-item">
             <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>

--- a/src/Views/Shared/_Layout_base.cshtml
+++ b/src/Views/Shared/_Layout_base.cshtml
@@ -23,10 +23,10 @@
     <![endif]-->
 
     <!--[if lt IE 9]>
-      <script src="~/vendor/html5shiv.min.js" asp-append-version="true"></script>
+      <script src="@Url.Content("~/vendor/html5shiv.min.js")" asp-append-version="true"></script>
     <![endif]-->
 
-    <meta property="og:image" content="/images/govuk-opengraph-image.png" />
+    <meta property="og:image" content="~/images/govuk-opengraph-image.png" />
 
     @RenderSection("head", required: false)
   </head>


### PR DESCRIPTION
### Context
We're currently referring to Open Government License in our Ts & Cs. UCAS hasn't agreed to give us republishing rights to their data in a way that's compatible with the OGL.

### Changes proposed in this pull request
Remove reference to open license

### Guidance to review
<img width="986" alt="screen shot 2018-09-24 at 10 40 10" src="https://user-images.githubusercontent.com/3071606/45945814-a8318100-bfe6-11e8-9c4c-a89990eaddfb.png">

