### PR TITLE
Redirect start page to LocationWizard

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -19,9 +19,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         private readonly ISearchAndCompareApi _api;
 
         private readonly IGeocoder _geocoder;
-        private readonly SearchConfig _searchConfig;
+        private readonly ISearchConfig _searchConfig;
 
-        public FilterController(ISearchAndCompareApi api, IGeocoder geocoder, SearchConfig searchConfig)
+        public FilterController(ISearchAndCompareApi api, IGeocoder geocoder, ISearchConfig searchConfig)
         {
             _api = api;
             _geocoder = geocoder;

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -165,9 +165,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
         [HttpGet("start/location")]
         [ActionName("LocationWizard")]
-        public IActionResult LocationWizardGet(ResultsFilter filter)
+        public IActionResult LocationWizardGet(ResultsFilter filter, string hideBack)
         {
             ViewBag.IsInWizard = true;
+            ViewBag.HideBack = hideBack == "True";
             return LocationGet(filter);
         }
 

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -19,11 +19,13 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         private readonly ISearchAndCompareApi _api;
 
         private readonly IGeocoder _geocoder;
+        private readonly SearchConfig _searchConfig;
 
-        public FilterController(ISearchAndCompareApi api, IGeocoder geocoder)
+        public FilterController(ISearchAndCompareApi api, IGeocoder geocoder, SearchConfig searchConfig)
         {
             _api = api;
             _geocoder = geocoder;
+            _searchConfig = searchConfig;
         }
 
         [HttpGet("results/filter/subject")]
@@ -165,10 +167,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
         [HttpGet("start/location")]
         [ActionName("LocationWizard")]
-        public IActionResult LocationWizardGet(ResultsFilter filter, string hideBack)
+        public IActionResult LocationWizardGet(ResultsFilter filter)
         {
             ViewBag.IsInWizard = true;
-            ViewBag.HideBack = hideBack == "True";
+            ViewBag.HideBack = !_searchConfig.PreLaunchMode;
             return LocationGet(filter);
         }
 

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -5,9 +5,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 {
     public class HomeController : CommonAttributesControllerBase
     {
-        private readonly SearchConfig _searchConfig;
+        private readonly ISearchConfig _searchConfig;
 
-        public HomeController(SearchConfig searchConfig)
+        public HomeController(ISearchConfig searchConfig)
         {
             _searchConfig = searchConfig;
         }

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -25,7 +25,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             // After launch there will be a gov.uk start page, so bounce users past ours and on to the location search
             return RedirectToAction("LocationWizard", "Filter");
-
         }
 
         [AllowAnonymous]

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -24,8 +24,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             }
 
             // After launch there will be a gov.uk start page, so bounce users past ours and on to the location search
-            const bool hideBack = true;
-            return RedirectToAction("LocationWizard", "Filter", new { hideBack });
+            return RedirectToAction("LocationWizard", "Filter");
 
         }
 

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -1,21 +1,15 @@
-﻿using System.Diagnostics;
-using GovUk.Education.SearchAndCompare.UI.ViewModels;
-using GovUk.Education.SearchAndCompare.UI.Services;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using GovUk.Education.SearchAndCompare.UI.ActionFilters;
-using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.SearchAndCompare.UI.Controllers
 {
-    //[Authorize]
     public class HomeController : CommonAttributesControllerBase
     {
-        private bool PreLaunchMode;
+        private readonly SearchConfig _searchConfig;
 
-        public HomeController(IConfiguration Configuration)
+        public HomeController(SearchConfig searchConfig)
         {
-            PreLaunchMode = !string.IsNullOrWhiteSpace(Configuration["SITE_PASSWORD"]);
+            _searchConfig = searchConfig;
         }
 
         [HttpGet("")]
@@ -23,12 +17,16 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("home/index")]
         public IActionResult Index()
         {
-            if (PreLaunchMode) {
+            // Before launch we don't have a gov.uk start page, so use our own.
+            if (_searchConfig.PreLaunchMode)
+            {
                 return View("Index");
-            } else {
-                bool hideBack = true;
-                return RedirectToAction("LocationWizard", "Filter", new { hideBack });
             }
+
+            // After launch there will be a gov.uk start page, so bounce users past ours and on to the location search
+            const bool hideBack = true;
+            return RedirectToAction("LocationWizard", "Filter", new { hideBack });
+
         }
 
         [AllowAnonymous]

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -4,18 +4,31 @@ using GovUk.Education.SearchAndCompare.UI.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using GovUk.Education.SearchAndCompare.UI.ActionFilters;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.SearchAndCompare.UI.Controllers
 {
     //[Authorize]
     public class HomeController : CommonAttributesControllerBase
     {
+        private bool PreLaunchMode;
+
+        public HomeController(IConfiguration Configuration)
+        {
+            PreLaunchMode = !string.IsNullOrWhiteSpace(Configuration["SITE_PASSWORD"]);
+        }
+
         [HttpGet("")]
         [HttpGet("home")]
         [HttpGet("home/index")]
         public IActionResult Index()
         {
-            return View("Index");
+            if (PreLaunchMode) {
+                return View("Index");
+            } else {
+                bool hideBack = true;
+                return RedirectToAction("LocationWizard", "Filter", new { hideBack });
+            }
         }
 
         [AllowAnonymous]

--- a/src/ISearchConfig.cs
+++ b/src/ISearchConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.SearchAndCompare.UI
+{
+    public interface ISearchConfig
+    {
+        bool PreLaunchMode { get; }
+        string SitePassword { get; }
+    }
+}

--- a/src/SearchConfig.cs
+++ b/src/SearchConfig.cs
@@ -2,7 +2,7 @@
 
 namespace GovUk.Education.SearchAndCompare.UI
 {
-    public class SearchConfig
+    public class SearchConfig : ISearchConfig
     {
         private readonly IConfiguration _configuration;
 

--- a/src/SearchConfig.cs
+++ b/src/SearchConfig.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.SearchAndCompare.UI
+{
+    public class SearchConfig
+    {
+        private readonly IConfiguration _configuration;
+
+        public SearchConfig(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public bool PreLaunchMode => !string.IsNullOrWhiteSpace(SitePassword);
+
+        /// <summary>
+        /// This will be set to prevent potential teachers seeing next year's course listings too early.
+        /// The password will be shared with providers and the internal team to be able to preview and check the data before going live.
+        /// Requires an app restart to take effect when set/cleared.
+        /// </summary>
+        public string SitePassword => _configuration["SITE_PASSWORD"];
+    }
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -30,7 +30,8 @@ namespace GovUk.Education.SearchAndCompare.UI
         {
             _logger = logFactory.CreateLogger<Startup>();
             Configuration = configuration;
-            _logger.LogInformation($"Pre-launch password protection: {PreLaunchMode}");
+            var searchConfig = new SearchConfig(Configuration);
+            _logger.LogInformation($"Pre-launch password protection: {searchConfig.PreLaunchMode}");
         }
 
         public IConfiguration Configuration { get; }
@@ -38,14 +39,15 @@ namespace GovUk.Education.SearchAndCompare.UI
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            var searchConfig = new SearchConfig(Configuration);
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
 
-            services.AddBasicAuth(SitePassword);
+            services.AddBasicAuth(searchConfig.SitePassword);
 
             var sharedAssembly = typeof(CourseDetailsViewComponent).GetTypeInfo().Assembly;
             services.AddMvc(config =>
                 {
-                    if (PreLaunchMode)
+                    if (searchConfig.PreLaunchMode)
                     {
                         // require authorized user for every request
                         config.Filters.Add(new AuthorizeFilter(
@@ -63,13 +65,15 @@ namespace GovUk.Education.SearchAndCompare.UI
             services.AddScoped<IGeocoder>(provider => new Geocoder(Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMaps")));
             services.AddScoped<IMapProvider>(provider => new MapProvider(new HttpClientProvider(), Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMapsStatic")));
 
-            services.AddSingleton<IConfiguration>(Configuration);
+            services.AddSingleton<SearchConfig, SearchConfig>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IServiceProvider serviceProvider)
         {
-            if (PreLaunchMode)
+            var config = serviceProvider.GetService<SearchConfig>();
+
+            if (config.PreLaunchMode)
             {
                 app.UseAuthentication();
             }
@@ -108,14 +112,5 @@ namespace GovUk.Education.SearchAndCompare.UI
                     defaults: new { controller = "Legal", action = "TandC" });
             });
         }
-
-        private bool PreLaunchMode => !string.IsNullOrWhiteSpace(SitePassword);
-
-        /// <summary>
-        /// This will be set to prevent potential teachers seeing next year's course listings too early.
-        /// The password will be shared with providers and the internal team to be able to preview and check the data before going live.
-        /// Requires an app restart to take effect when set/cleared.
-        /// </summary>
-        private string SitePassword => Configuration["SITE_PASSWORD"];
     }
 }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI
         {
             _logger = logFactory.CreateLogger<Startup>();
             Configuration = configuration;
-            var searchConfig = new SearchConfig(Configuration);
+            ISearchConfig searchConfig = new SearchConfig(Configuration);
             _logger.LogInformation($"Pre-launch password protection: {searchConfig.PreLaunchMode}");
         }
 
@@ -39,7 +39,7 @@ namespace GovUk.Education.SearchAndCompare.UI
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            var searchConfig = new SearchConfig(Configuration);
+            ISearchConfig searchConfig = new SearchConfig(Configuration);
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
 
             services.AddBasicAuth(searchConfig.SitePassword);
@@ -65,13 +65,13 @@ namespace GovUk.Education.SearchAndCompare.UI
             services.AddScoped<IGeocoder>(provider => new Geocoder(Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMaps")));
             services.AddScoped<IMapProvider>(provider => new MapProvider(new HttpClientProvider(), Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMapsStatic")));
 
-            services.AddSingleton<SearchConfig, SearchConfig>();
+            services.AddSingleton<ISearchConfig, SearchConfig>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, IServiceProvider serviceProvider)
         {
-            var config = serviceProvider.GetService<SearchConfig>();
+            var config = serviceProvider.GetService<ISearchConfig>();
 
             if (config.PreLaunchMode)
             {

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -62,6 +62,8 @@ namespace GovUk.Education.SearchAndCompare.UI
             services.AddScoped<AnalyticsAttribute>();
             services.AddScoped<IGeocoder>(provider => new Geocoder(Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMaps")));
             services.AddScoped<IMapProvider>(provider => new MapProvider(new HttpClientProvider(), Configuration.GetSection("ApiKeys").GetValue<string>("GoogleMapsStatic")));
+
+            services.AddSingleton<IConfiguration>(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -2,14 +2,15 @@
 
 @{
   ViewBag.Title = $"Find courses by location or by training provider";
-  var isInWizard = ViewBag.IsInWizard == true;
+  var isInWizard = ViewBag.IsInWizard;
+  var showBack = !ViewBag.HideBack;
   var selectedRadius = (Model.FilterModel.rad.HasValue) ? Model.FilterModel.rad : (int)RadiusOption.TwentyMiles;
 }
 
-@if (isInWizard) {
+@if (isInWizard && showBack) {
   @Html.Partial("Back", new BackLinkViewModel { Href = Url.Action("Index", "Home"), Title = "Back" })
 }
-else
+else if (!isInWizard)
 {
   @Html.Partial("Back", new BackLinkViewModel { Href = Url.Action("Index", "Results", Model.FilterModel.ToRouteValues()), Title = "Back to search results" })
 }

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -7,10 +7,14 @@
   var selectedRadius = (Model.FilterModel.rad.HasValue) ? Model.FilterModel.rad : (int)RadiusOption.TwentyMiles;
 }
 
-@if (isInWizard && showBack) {
-  @Html.Partial("Back", new BackLinkViewModel { Href = Url.Action("Index", "Home"), Title = "Back" })
+@if (isInWizard)
+{
+  if (showBack)
+  {
+    @Html.Partial("Back", new BackLinkViewModel { Href = Url.Action("Index", "Home"), Title = "Back" })
+  }
 }
-else if (!isInWizard)
+else
 {
   @Html.Partial("Back", new BackLinkViewModel { Href = Url.Action("Index", "Results", Model.FilterModel.ToRouteValues()), Title = "Back to search results" })
 }

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MockQueryable.Moq" Version="1.0.1" />
     <PackageReference Include="Moq" Version="4.8.0" />

--- a/tests/Unit.Tests/Controllers/HomeControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/HomeControllerTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using GovUk.Education.SearchAndCompare.UI;
+using GovUk.Education.SearchAndCompare.UI.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
+{
+    [TestFixture]
+    public class HomeControllerTests
+    {
+        private Mock<ISearchConfig> _searchConfigMock;
+        private HomeController _homeController;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _searchConfigMock = new Mock<ISearchConfig>();
+            _homeController = new HomeController(_searchConfigMock.Object);
+        }
+
+        [Test]
+        public void ReturnsIndexForPreLaunch()
+        {
+            _searchConfigMock.SetupGet(c => c.PreLaunchMode).Returns(true);
+            var result = _homeController.Index();
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = (ViewResult)result;
+            viewResult.ViewName.Should().Be("Index");
+        }
+
+        [Test]
+        public void RedirectsForPostLaunch()
+        {
+            _searchConfigMock.SetupGet(c => c.PreLaunchMode).Returns(false);
+            var result = _homeController.Index();
+            result.Should().BeOfType<RedirectToActionResult>();
+        }
+    }
+}

--- a/tests/Unit.Tests/Controllers/SubjectGetTests.cs
+++ b/tests/Unit.Tests/Controllers/SubjectGetTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using GovUk.Education.SearchAndCompare.Domain.Client;
 using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI;
 using GovUk.Education.SearchAndCompare.UI.Controllers;
 using GovUk.Education.SearchAndCompare.UI.Filters;
 using GovUk.Education.SearchAndCompare.UI.Services;
@@ -42,7 +43,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         {
             var mockApi = GetMockApi(_subjectAreas);
             var mockGeocoder = new Mock<IGeocoder>();
-            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object);
+            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object, new Mock<ISearchConfig>().Object);
             var tempDataMock = new Mock<ITempDataDictionary>();
             _filterController.TempData = tempDataMock.Object;
 

--- a/tests/Unit.Tests/SearchConfigTests.cs
+++ b/tests/Unit.Tests/SearchConfigTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using GovUk.Education.SearchAndCompare.UI;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests
+{
+    [TestFixture]
+    public class SearchConfigTests
+    {
+        [Test]
+        public void NoPassword()
+        {
+            var mockConfig = new Mock<IConfiguration>();
+            ISearchConfig searchConfig = new SearchConfig(mockConfig.Object);
+            searchConfig.SitePassword.Should().BeNull();
+            searchConfig.PreLaunchMode.Should().BeFalse("no password when live");
+        }
+
+        [Test]
+        public void PrelaunchPassword()
+        {
+            var mockConfig = new Mock<IConfiguration>();
+            const string password = "correct horse battery staple";
+            mockConfig.Setup(c => c["SITE_PASSWORD"]).Returns(password);
+            ISearchConfig searchConfig = new SearchConfig(mockConfig.Object);
+            searchConfig.SitePassword.Should().Be(password);
+            searchConfig.PreLaunchMode.Should().BeTrue("password set when live");
+        }
+    }
+}


### PR DESCRIPTION
### Context

Our start page will live on GOV.UK for go live, so we need to redirect the home/index route.

### Changes proposed in this pull request

Updates the controller to redirect, and removes the back button.

### Guidance to review

I couldn't find tests for the files I touched, and I'm not sure if we should delete the view file for the home/index route.