### PR TITLE
Remove UCAS search reference

### DIFF
--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -22,7 +22,3 @@
       }
     </ul>
 }
-
-<p class="govuk-body">
-  You can <a href="https://www.ucas.com/ucas/teacher-training/ucas-teacher-training-search-training-programmes" class="govuk-link">search for courses in other subjects</a> on the UCAS website.
-</p>


### PR DESCRIPTION
This was a hold-over from the private beta.
