### PR TITLE
Display a minimum about section on courses

### DIFF
--- a/shared/ViewModels/CourseDetailsViewModel.cs
+++ b/shared/ViewModels/CourseDetailsViewModel.cs
@@ -52,6 +52,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
 
         public bool HasFeesSet => Course?.Fees != null ;
 
+        public bool HasWebsite => !string.IsNullOrEmpty(Course.ContactDetails.Website);
+
+        public bool HasContentForAboutSection => HasSection(CourseDetailsSections.AboutTheCourse);
+
+        public bool ShowMinimumAboutCourseSection => !HasContentForAboutSection && !PreviewMode && HasWebsite;
+
+        public bool ShowWebsite => HasWebsite && !ShowMinimumAboutCourseSection;
+
         public HtmlString GetHtmlForSection(string name)
         {
             if (!HasSection(name))

--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -58,7 +58,7 @@
             <dt class="govuk-list--description__label">Date course starts</dt>
             <dd>@Model.Course.FormattedStartDate()</dd>
           }
-          @if (!string.IsNullOrEmpty(@Model.Course.ContactDetails.Website)) {
+          @if (Model.ShowWebsite) {
             <dt class="govuk-list--description__label">Website</dt>
             <dd>
               <a href="@Model.Course.FormattedWebsite()" title="Go to course website" aria-label="Go to course website" class="govuk-link">@Model.Course.FormattedWebsite()</a>
@@ -74,7 +74,7 @@
       <div class="course-contents govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-m">Contents</h2>
           <ul class="govuk-list govuk-list--dash">
-            @if (Model.PreviewMode || Model.HasSection(CourseDetailsSections.AboutTheCourse))
+            @if (Model.PreviewMode || Model.HasSection(CourseDetailsSections.AboutTheCourse) || Model.ShowMinimumAboutCourseSection)
             {
               <li><a href="#section-about">About the course</a></li>
             }
@@ -123,7 +123,10 @@
           </ul>
         </div>
 
-        @await Html.PartialAsync("_AboutCourse.cshtml")
+        @if (Model.PreviewMode || Model.HasSection(CourseDetailsSections.AboutTheCourse) || Model.ShowMinimumAboutCourseSection)
+        {
+          @await Html.PartialAsync("_AboutCourse.cshtml")
+        }
 
         @await Html.PartialAsync("_InterviewProcess.cshtml")
 

--- a/shared/Views/Shared/Components/CourseDetails/_AboutCourse.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_AboutCourse.cshtml
@@ -9,18 +9,22 @@
   var section = Model.GetHtmlForSection(CourseDetailsSections.AboutTheCourse);
 }
 
-@if (Model.PreviewMode || Model.HasSection(CourseDetailsSections.AboutTheCourse))
-{
-  <div class="govuk-!-margin-bottom-8">
-    <h2 class="govuk-heading-l" id="section-about">About the course</h2>
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-about">About the course</h2>
 
-    @if (section != null)
-    {
-      @Html.Raw(section)
-    }
-    else
-    {
-      <p class="missing-section">Please add details for this section.</p>
-    }
-  </div>
-}
+  @if (section != null)
+  {
+    @Html.Raw(section)
+  }
+  else if (Model.PreviewMode)
+  {
+    <p class="missing-section">Please add details for this section.</p>
+  }
+  else
+  {
+    <div class="govuk-inset-text">
+      Find out more at:<br />
+      <a href="@Model.Course.FormattedWebsite()" title="Go to course website" aria-label="Go to course website" class="govuk-link">@Model.Course.FormattedWebsite()</a>
+    </div>
+  }
+</div>


### PR DESCRIPTION
### Context

When a course doesn't have an about section on it, but the provider does have a website defined in their contact details, we should display a minimum "About the course" section highlighting the website.

As discussed with @fofr, we should hide the website from the main contact details section in this situation to avoid duplicating it.

We should also not display it when the user is in preview mode.

Reference design: https://search-and-compare-prototype.herokuapp.com/public/images/history/mvp-iteration-jul-25/05-minimum-course-page.png

### Changes proposed in this pull request

Updates the ViewModel with helper variables with descriptive names that hoist the logic, which are then used in the view.