### PR TITLE
Tweak funding and salary copy

### DIFF
--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -25,7 +25,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <p class="govuk-body">
-            On a salaried course you’ll be paid and taxed as an unqualified teacher. The salary awarded will differ between schools; you should check the salary with the school before you apply.
+            On a salaried course you’ll be paid and taxed as an unqualified teacher. The salary awarded will differ between schools – you should check the salary with the school before you apply.
           </p>
           <p class="govuk-body">
             Salaried courses are not eligible for bursaries, scholarships or student finance. There are usually no course fees to pay.

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -30,10 +30,9 @@
             <h1 class="govuk-heading-xl">Find courses by subject</h1>
           </legend>
           <p class="govuk-body">Select the subjects you want to teach.</p>
-          <h2 class="govuk-heading-m">Get more financial support</h2>
-          <p class="govuk-body">Most courses charge a fee. The financial support options available to you will depend on the subject you choose.</p>
-          <p class="govuk-body">For some subjects you could be eligible for up to £28,000 tax-free while you train, through a bursary or scholarship.</p>
-          <p class="govuk-body">Student finance is available for all subjects.</p>
+          <h2 class="govuk-heading-m">Get financial support</h2>
+          <p class="govuk-body">Most courses charge a fee. You can get financial support to help with the costs of your course. The financial support options available to you will depend on the subject you choose.</p>
+          <p class="govuk-body">Find out more about <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans">postgraduate loans</a>, <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview">bursaries and scholarships</a> and <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject">funding by subject</a> on Get into Teaching.</p>
           <form action='@Url.Action(isInWizard ? "SubjectWizard" : "Subject", "Filter", Model.FilterModel.WithoutSubjects().ToRouteValues())' method="POST" id="subjects-container">
             <div class="accordion" data-module="accordion">
               @foreach (var area in Model.SubjectAreas) {


### PR DESCRIPTION
* Shorten the finance copy on the subject selector
* Remove a stray semicolon in the salary filter

