### PR TITLE
Fix course page title

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -5,10 +5,6 @@
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters;
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
 
-@{
-  ViewBag.Title = $"{Model.Course.Name} at {Model.Provider.Name}";
-}
-
 <div data-module="back-link"></div>
 
 @if (Model.PreviewMode)

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -1,3 +1,7 @@
 @model GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel
 
+@{
+  ViewBag.Title = $"{Model.Course.Name} with {Model.Provider.Name}";
+}
+
 @await Component.InvokeAsync("CourseDetails", new { course = Model })


### PR DESCRIPTION
### Context
Course page is missing title

### Changes proposed in this pull request
Correct level in code where page title is set

### Guidance to review
View any course details page
