### PR TITLE
Display subject name in suggestions

### DIFF
--- a/src/ViewModels/SuggestedSearchesViewModel.cs
+++ b/src/ViewModels/SuggestedSearchesViewModel.cs
@@ -9,5 +9,9 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewModels
         public List<SuggestedSearchViewModel> SuggestedSearches { get; set; }
         public ResultsViewModel OriginalResults { get; set; }
         public bool HasSalary { get; internal set; }
+
+        public string SelectedSubject {
+            get { return OriginalResults.Subjects.Items.Count == 1 ? OriginalResults.Subjects.Items[0].Name : null; }
+        }
     }
 }

--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -3,22 +3,31 @@
 <h3 class="govuk-heading-m">Suggested searches</h3>
 
 @if(Model.SuggestedSearches.Any()) {
-    <p class="govuk-body">There are:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      @foreach (var item in Model.SuggestedSearches)
-      {
-        var courseText = " course" + (item.TotalCount == 1 ? "" : "s");
-        var areaText = item.ResultsFilter?.rad != null && item.ResultsFilter?.loc != null ?
-          " within " + item.ResultsFilter.rad + " miles of " + item.ResultsFilter.loc :
-          (
-            Model.HasSalary ?
-              " with " + item.ResultsFilter.GetFundingTypes().First().ToLowerInvariant() + " available in England" :
-              " across England" );
-        var text = item.TotalCount + courseText + areaText;
+  @if (Model.SelectedSubject != null)
+  {
+    <p class="govuk-body">For @Model.SelectedSubject you can find:</p>
+  }
+  else
+  {
+    <p class="govuk-body">You can find:</p>
+  }
+  <ul class="govuk-list govuk-list--bullet">
+    @foreach (var item in Model.SuggestedSearches)
+    {
+      var courseText = item.TotalCount == 1
+        ? " course"
+        : " courses";
+      var salaryText = Model.HasSalary
+        ? " with or without a salary"
+        : "";
+      var areaText = item.ResultsFilter?.rad != null
+        ? " within " + item.ResultsFilter.rad + " miles"
+        : " across England";
+      var text = item.TotalCount + courseText + salaryText + areaText;
 
-          <li>
-            <a href="@(Url.Action("Index", "Results", item.ResultsFilter.ToRouteValues()))" class="govuk-link">@text</a>
-          </li>
-      }
-    </ul>
+      <li>
+        <a href="@(Url.Action("Index", "Results", item.ResultsFilter.ToRouteValues()))" class="govuk-link">@text</a>
+      </li>
+    }
+  </ul>
 }


### PR DESCRIPTION
### Context

This is to clarify that the search results are relevant to the query.

We don't display any subject if there's more than one selected.

Also updates the content when searching for salaries, and removes redundant location information.

### Changes proposed in this pull request

Adds a new field to the View Model and calls it in the view when necessary, updates view logic.

### Guidance to review

I'm not sure if this needs `?.`'s? IDE didn't complain…

### Screenshots

![screen shot 2018-09-26 at 15 35 35](https://user-images.githubusercontent.com/1650875/46087766-f3908e80-c1a2-11e8-9f2c-c98d462faa57.png)

![screen shot 2018-09-26 at 15 35 08](https://user-images.githubusercontent.com/1650875/46087781-f5f2e880-c1a2-11e8-9f4e-eab0ba31c6fa.png)
