### PR TITLE
Don't show the day of the month when rendering the course start date

### DIFF
--- a/shared/ViewFormatters/CourseExtensions.cs
+++ b/shared/ViewFormatters/CourseExtensions.cs
@@ -94,7 +94,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters
 
             if (!date.HasValue) { return string.Empty; }
 
-            return date.Value.ToString("d MMMM yyyy", CultureInfo.CreateSpecificCulture("en-US"));
+            // n.b. Ucas only specifies the month and year of the course start, so do not display
+            // a day here.
+            return date.Value.ToString("MMMM yyyy", CultureInfo.CreateSpecificCulture("en-US"));
         }
 
         public static string FundingOptions(this Course course)


### PR DESCRIPTION
### Context

https://trello.com/c/9BAnkbC6/385-we-need-to-show-course-start-date-on-details-page

### Changes proposed in this pull request

Ucas only gives us the year and month for this, so the day in this
DateTime is meaningless and misleading. Only render the month and the
year.

