### PR TITLE
When searching by provider show name in page title

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -33,11 +33,6 @@
             <dt class="govuk-list--description__label">Course offered</dt>
             <dd>@Model.Course.Mod</dd>
           }
-          @if (Model.Course.ProviderLocation != null)
-          {
-            <dt class="govuk-list--description__label">Location</dt>
-            <dd>@Model.Course.ProviderLocation.Address</dd>
-          }
           <dt class="govuk-list--description__label">Qualification</dt>
           <dd>
             @await Html.PartialAsync("_Qualification.cshtml")

--- a/src/Views/Results/Index.cshtml
+++ b/src/Views/Results/Index.cshtml
@@ -8,10 +8,18 @@
 }
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        Teacher training courses
-      </h1>
+    <div class="govuk-grid-column-full">
+      @if (string.IsNullOrWhiteSpace(Model.FilterModel.query))
+      {
+        <h1 class="govuk-heading-xl">Teacher training courses</h1>
+      }
+      else
+      {
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-l">Teacher training courses</span>
+          @Model.FilterModel.query
+        </h1>
+      }
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/src/Views/Results/Index.cshtml
+++ b/src/Views/Results/Index.cshtml
@@ -2,10 +2,14 @@
 
 @{
   Layout = "~/Views/Shared/_Layout.cshtml";
-  ViewBag.Title = Model.Courses != null && Model.Courses.TotalCount > 0
+
+  ViewBag.Title =
+    (Model.Courses != null && Model.Courses.TotalCount > 0
     ? $"{string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:n0}", Model.Courses.TotalCount)} courses"
-    : "No courses found";
+    : "No courses found")
+    + (string.IsNullOrWhiteSpace(Model.FilterModel.query) ? "" : $" - {Model.FilterModel.query}");
 }
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">


### PR DESCRIPTION
### Context
https://trello.com/c/7nWnFyMq

### Changes proposed in this pull request
Display provider name for header level 1 searching for subjects by provider

### Guidance to review
# Search by location or across england
<img width="1392" alt="screen shot 2018-09-26 at 14 49 03" src="https://user-images.githubusercontent.com/3071606/46084305-45351b00-c19b-11e8-90df-6d32ba741197.png">

# Search by provider
<img width="1392" alt="screen shot 2018-09-26 at 14 48 54" src="https://user-images.githubusercontent.com/3071606/46084306-45351b00-c19b-11e8-9068-66043af0b252.png">