### PR TITLE
Hide accredited provider when name is identical to provider

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -20,7 +20,7 @@
       <h1 class="govuk-heading-xl">
         @Model.Course.Name with @Model.Provider.Name
 
-        @if (!String.IsNullOrEmpty(Model.Course.AccreditingProvider?.Name))
+        @if (!string.IsNullOrEmpty(Model.Course.AccreditingProvider?.Name) && Model.Provider.Name != Model.Course.AccreditingProvider?.Name)
         {
           <span class="govuk-caption-xl">Accredited provider: @Model.Course.AccreditingProvider?.Name</span>
         }

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -11,6 +11,7 @@
 <ul class="govuk-list search-results">
   @foreach (var item in Model.Courses.Items) {
     var subjects = @item.CourseSubjects.Select(courseSubject => courseSubject.Subject.Name).ToArray();
+
     <li>
       <h3 class="govuk-heading-m">
         <a href='@Url.Action("Index", "Course", new {courseCode = item.ProgrammeCode, providerCode = item.Provider.ProviderCode})' class="link">@item.Name with @item.Provider.Name</a>
@@ -21,7 +22,7 @@
           <dt class="govuk-list--description__label">Course offered</dt>
           <dd>@item.Mod</dd>
         }
-        @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name))
+        @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name) && item.Provider.Name != item.AccreditingProvider?.Name)
         {
           <dt class="govuk-list--description__label">Accredited provider</dt>
           <dd>@item.AccreditingProvider.Name</dd>


### PR DESCRIPTION
This eliminates some redundancy from the UI.

### Screenshots

| Before | After |
|-|-|
| ![screen shot 2018-09-26 at 16 49 55](https://user-images.githubusercontent.com/1650875/46093122-6e12db80-c1ae-11e8-9c01-77bcbbbf6003.png) |  ![screen shot 2018-09-26 at 16 51 53](https://user-images.githubusercontent.com/1650875/46093123-6e12db80-c1ae-11e8-8601-fa7dcbd729ac.png) |

| Details (matching provider name) | Details (non-matching) |
|-|-|
| ![screen shot 2018-09-26 at 17 04 57](https://user-images.githubusercontent.com/1650875/46093125-6e12db80-c1ae-11e8-86bc-0b63b6d92e42.png) | ![screen shot 2018-09-26 at 17 05 20](https://user-images.githubusercontent.com/1650875/46093126-6eab7200-c1ae-11e8-8eca-477722b552b1.png) |
