### PR TITLE
Open a subject accordion section when it contains a ticked checkbox

### DIFF
--- a/src/Assets/Javascript/accordion.js
+++ b/src/Assets/Javascript/accordion.js
@@ -4,13 +4,13 @@ function Accordion($module) {
   this.$module = $module
 }
 
-Accordion.prototype.init = function () {
+Accordion.prototype.init = function (options) {
   if (document.querySelectorAll && window.NodeList && 'classList' in document.body) {
     this.sections = []
     var accordion_sections = this.$module.querySelectorAll('.accordion-section')
     var accordion = this
     for (var i = accordion_sections.length - 1; i >= 0; i--) {
-      accordion.sections.push(new AccordionSection(accordion_sections[i], accordion))
+      accordion.sections.push(new AccordionSection(accordion_sections[i], accordion, options))
     };
     var accordion_controls = document.createElement('div')
     accordion_controls.setAttribute('class', 'accordion-controls')
@@ -59,14 +59,15 @@ Accordion.prototype.updateOpenAll = function() {
   }
 }
 
-function AccordionSection(element, accordion) {
+function AccordionSection(element, accordion, options) {
   this.$module = element
   this.accordion = accordion
-  this.setup()
+  this.setup(options)
 }
 
-AccordionSection.prototype.setup = function() {
-  var sectionExpanded = this.$module.classList.contains('accordion-section--expanded')
+AccordionSection.prototype.setup = function (options) {
+  var forceSectionExpanded = options.forceSectionExpandedFn && options.forceSectionExpandedFn(this.$module);
+  var sectionExpanded = forceSectionExpanded || this.$module.classList.contains('accordion-section--expanded')
   this.$module.setAttribute('aria-expanded', sectionExpanded)
   var header = this.$module.querySelector('.accordion-section-header')
   header.addEventListener('click', this.toggleExpanded.bind(this))

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -16,7 +16,11 @@ new BackLink($backLink).init();
 
 var $accordions = document.querySelectorAll('[data-module="accordion"]')
 for (var i = $accordions.length - 1; i >= 0; i--) {
-  new Accordion($accordions[i]).init();
+  new Accordion($accordions[i]).init({
+    forceSectionExpandedFn: function ($accordionSection) {
+      return !!$accordionSection.querySelector('.govuk-checkboxes input[type="checkbox"]:checked');
+    }
+  });
 };
 
 var $toggle = document.querySelectorAll('[data-module="toggle"]')

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -43,8 +43,8 @@
                     <div class="govuk-checkboxes">
                       @foreach (var subject in area.Subjects.OrderBy(x => x.Name)) {
                         <div class="govuk-checkboxes__item">
-                          <input id="@("subject- " + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input">
-                          <label for="@("subject- " + subject.Id)" class="govuk-label govuk-checkboxes__label">
+                          <input id="@("subject-" + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input">
+                          <label for="@("subject-" + subject.Id)" class="govuk-label govuk-checkboxes__label">
                             <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2">
                               @subject.Name
                             </span>


### PR DESCRIPTION
### Context

This is to maintain the state of the page when users browse back from the results

Also contains a fix for the IDs on subject filter checkboxes.

### Changes proposed in this pull request

Adds an `options` object to the accordion component that allows consumers to pass in a `forceSectionExpandedFn` as an escape hatch. The reason for this approach is in order to hoist the checkbox-specific logic outside of the component itself.