### PR TITLE
Open a subject accordion section when it contains a ticked checkbox

### DIFF
--- a/src/Assets/Javascript/accordion.js
+++ b/src/Assets/Javascript/accordion.js
@@ -4,13 +4,13 @@ function Accordion($module) {
   this.$module = $module
 }
 
-Accordion.prototype.init = function (options) {
+Accordion.prototype.init = function () {
   if (document.querySelectorAll && window.NodeList && 'classList' in document.body) {
     this.sections = []
     var accordion_sections = this.$module.querySelectorAll('.accordion-section')
     var accordion = this
     for (var i = accordion_sections.length - 1; i >= 0; i--) {
-      accordion.sections.push(new AccordionSection(accordion_sections[i], accordion, options))
+      accordion.sections.push(new AccordionSection(accordion_sections[i], accordion))
     };
     var accordion_controls = document.createElement('div')
     accordion_controls.setAttribute('class', 'accordion-controls')
@@ -59,15 +59,14 @@ Accordion.prototype.updateOpenAll = function() {
   }
 }
 
-function AccordionSection(element, accordion, options) {
+function AccordionSection(element, accordion) {
   this.$module = element
   this.accordion = accordion
-  this.setup(options)
+  this.setup()
 }
 
-AccordionSection.prototype.setup = function (options) {
-  var forceSectionExpanded = options.forceSectionExpandedFn && options.forceSectionExpandedFn(this.$module);
-  var sectionExpanded = forceSectionExpanded || this.$module.classList.contains('accordion-section--expanded')
+AccordionSection.prototype.setup = function() {
+  var sectionExpanded = this.$module.classList.contains('accordion-section--expanded')
   this.$module.setAttribute('aria-expanded', sectionExpanded)
   var header = this.$module.querySelector('.accordion-section-header')
   header.addEventListener('click', this.toggleExpanded.bind(this))

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -16,11 +16,15 @@ new BackLink($backLink).init();
 
 var $accordions = document.querySelectorAll('[data-module="accordion"]')
 for (var i = $accordions.length - 1; i >= 0; i--) {
-  new Accordion($accordions[i]).init({
-    forceSectionExpandedFn: function ($accordionSection) {
-      return !!$accordionSection.querySelector('.govuk-checkboxes input[type="checkbox"]:checked');
+  var $sections = $accordions.querySelectorAll('.accordion-section')
+  for (var j = $sections.length - 1; j >= 0; j--) {
+    var $section = $sections[j];
+    var sectionContainsCheckedCheckboxes = !!$section.querySelector('.govuk-checkboxes input[type="checkbox"]:checked')
+    if (sectionContainsCheckedCheckboxes) {
+      $section.classList.add('accordion-section--expanded')
     }
-  });
+  }
+  new Accordion($accordions[i]).init()
 };
 
 var $toggle = document.querySelectorAll('[data-module="toggle"]')


### PR DESCRIPTION
### Context

This is a better version of this previous PR:

- https://github.com/DFE-Digital/search-and-compare-ui/pull/156

### Changes proposed in this pull request

This manually adds the `accordion-section--expanded` to relevant sections using JavaScript that runs before the Accordions initialise.