### PR TITLE
When searching by provider, hide sort-by

### DIFF
--- a/src/Views/Shared/SortBy.cshtml
+++ b/src/Views/Shared/SortBy.cshtml
@@ -16,7 +16,7 @@
     </div>
 }
 
-@if (!Model.FilterModel.DisplayAsMap) {
+@if (!Model.FilterModel.DisplayAsMap && string.IsNullOrWhiteSpace(Model.FilterModel.query)) {
     <form action='@Url.Action("SortBy", "Results", Model.FilterModel.ToRouteValues())' method="POST">
         <div class="govuk-form-group">
             <label class="govuk-label govuk-label--inline sortedby-label" for="sortby">Sorted by</label>


### PR DESCRIPTION
### Context

https://trello.com/c/i2nx7BPC/401-sort-searching-by-training-provider-to-put-the-provider-first-followed-by-providers-they-accredit#

### Changes proposed in this pull request

Small change to hide Sort-by drop down when searching by provider


