### PR TITLE
Fix suggested searches header appearing when there are no searches

### DIFF
--- a/src/Views/Results/Components/SuggestedSearch/Default.cshtml
+++ b/src/Views/Results/Components/SuggestedSearch/Default.cshtml
@@ -1,8 +1,8 @@
 @model SuggestedSearchesViewModel
 
-<h3 class="govuk-heading-m">Suggested searches</h3>
-
 @if(Model.SuggestedSearches.Any()) {
+  <h3 class="govuk-heading-m">Suggested searches</h3>
+
   @if (Model.SelectedSubject != null)
   {
     <p class="govuk-body">For @Model.SelectedSubject you can find:</p>


### PR DESCRIPTION
#### Before

<img width="1057" alt="screenshot 2018-09-27 at 15 50 51" src="https://user-images.githubusercontent.com/1650875/46154525-4767aa00-c26d-11e8-8c7b-95634aab83b9.png">

#### After

<img width="1055" alt="screenshot 2018-09-27 at 15 50 39" src="https://user-images.githubusercontent.com/1650875/46154524-4767aa00-c26d-11e8-9aac-18d352b8e60c.png">