### PR TITLE
Fix the salary filter

### DIFF
--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -45,8 +45,8 @@
                 </label>
               </div>
             </div>
-            <input type="hidden" name="includeBursary" value="true">
-            <input type="hidden" name="includeScholarship" value="true">
+            <input type="hidden" name="includeBursary" value="false">
+            <input type="hidden" name="includeScholarship" value="false">
             <input type="hidden" name="includeSalary" value="true">
           </div>
         </fieldset>


### PR DESCRIPTION
The salary filter erroneously included scholarships and bursaries.

This is a HTML only change (no tests).