### PR TITLE
Allow users to add spaces between brackets in markdown links

### DIFF
--- a/shared/Utils/MarkdownFormatter.cs
+++ b/shared/Utils/MarkdownFormatter.cs
@@ -5,10 +5,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Utils
 {
     public class MarkdownFormatter
     {
-        private static readonly Regex linkRegex = new Regex(@"\[ *([^\]\n]+) *\](?:\( *((?:[^\\\(\)\s\n]|\\\(|\\\)|\\\\)+) *\))?", RegexOptions.Compiled | RegexOptions.Multiline);
-		private static readonly Regex listItemRegex = new Regex(@"^\s*(?:-|\*|[0-9]+\.?)[\t\f\v ](.*)\n?", RegexOptions.Compiled | RegexOptions.Multiline);
-		private static readonly Regex listWrapperRegex = new Regex(@"<li>(?:<\/li>\s*<li>|(?!<\/li>).)*<\/li>", RegexOptions.Compiled );
-		private static readonly Regex paragraphRegex = new Regex(@"^\s*[^<].*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex linkRegex = new Regex(@"\[ *([^\]\n]+) *\] ?(?:\( *((?:[^\\\(\)\s\n]|\\\(|\\\)|\\\\)+) *\))?", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex listItemRegex = new Regex(@"^\s*(?:-|\*|[0-9]+\.?)[\t\f\v ](.*)\n?", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex listWrapperRegex = new Regex(@"<li>(?:<\/li>\s*<li>|(?!<\/li>).)*<\/li>", RegexOptions.Compiled );
+        private static readonly Regex paragraphRegex = new Regex(@"^\s*[^<].*$", RegexOptions.Compiled | RegexOptions.Multiline);
 
         private static readonly Regex lineBreakRegex = new Regex(@"\n\s*", RegexOptions.Compiled);
         private static readonly Regex whitespace = new Regex(@"^\s*$", RegexOptions.Compiled);

--- a/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
+++ b/tests/Unit.Tests/Utils/MarkdownFormatter.Tests.cs
@@ -76,6 +76,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Utils
         }
 
         [Test]
+        public void NamedLinkWithSpace()
+        {
+            var markdown = "[Go to www.example.com] (www.example.com)";
+            var expected = "<p class=\"govuk-body\"><a href=\"www.example.com\" class=\"govuk-link\">Go to www.example.com</a></p>";
+            Assert.That(GetHtml(markdown), Is.EqualTo(expected));
+        }
+
+        [Test]
         public void LinkInParagraph()
         {
             var markdown = "Go to [our website](www.example.com).\nYou'll like it there.";


### PR DESCRIPTION
### Context

Markdown doesn't like this:

```
[link] (url)
```

But our users do it often enough that it's worth us adding an edge case for it in the formatter.

### Changes proposed in this pull request

This updates the markdown parser regex and the tests.