### PR TITLE
Add basic financial support to details page

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -33,6 +33,8 @@
             <dt class="govuk-list--description__label">Course offered</dt>
             <dd>@Model.Course.Mod</dd>
           }
+          <dt class="govuk-list--description__label">Financial support</dt>
+          <dd>@Model.Course.FundingOptions()</dd>
           <dt class="govuk-list--description__label">Qualification</dt>
           <dd>
             @await Html.PartialAsync("_Qualification.cshtml")


### PR DESCRIPTION
### Context
Show users financial support on course details page

### Changes proposed in this pull request
Add basic financial support as per results page.

I think we could expand this to show actual figures cc @fofr 

### Guidance to review

<img width="878" alt="screen shot 2018-09-28 at 12 26 27" src="https://user-images.githubusercontent.com/3071606/46205750-c31f3080-c319-11e8-81b7-49df26dea19b.png">
