### PR TITLE
Tweak to maths incentive information after fact-check

### DIFF
--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -64,7 +64,7 @@
 
                               if (txt != null && subject.Funding?.EarlyCareerPayments != null)
                               {
-                                  txt += $" with further early career payments of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.EarlyCareerPayments.Value)}.";
+                                  txt += $", with early career payments of £5,000 each in your third and fifth year of teaching (£7,500 each in some areas of England).";
                               }
                               else if (txt != null)
                               {


### PR DESCRIPTION
### Context
https://www.gov.uk/government/publications/mathematics-early-career-payments-guidance-for-teachers-and-schools

### Changes proposed in this pull request
Content tweaks

### Guidance to review
I've hard-coded numbers rather than using the database values as the data model doesn't quite fit what we need to present here. The numbers won't change for at least a year.