### PR TITLE
Cope gracefully with api returning null for courses

### DIFF
--- a/src/ViewComponents/SuggestedSearch.cs
+++ b/src/ViewComponents/SuggestedSearch.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewComponents
 
         public Task<IViewComponentResult> InvokeAsync(ResultsViewModel original, int maxResult)
         {
-            var originalTotal = original.Courses.TotalCount;
+            var originalTotal = original.Courses?.TotalCount ?? 0;
 
             var hasSalary = 
                 original.FilterModel.SelectedFunding.HasValue && 


### PR DESCRIPTION
The api shouldn't be returning null for the filter I'm looking at but seeing as it does let's get rid of the not very helpful null ref exception. It seems reasonable to interpret a null response for courses from the api as meaning there are zero courses.

Note that this doesn't fix the reported issue as the link says 24 courses but the api isn't returning any. Will investigate further.
