### PR TITLE
Tweak advice for contacting provider

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/_Advice.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_Advice.cshtml
@@ -1,5 +1,5 @@
 <h3 class="govuk-heading-l" id="section-advice">Advice and support</h3>
-<p class="govuk-body">For questions about this course you should <a href="#contact_section">contact the training provider.</a></p>
+<p class="govuk-body">For questions about this course you should contact the training provider using <a href="#contact_section">the contact details above</a>.</p>
 
 <h4 class="govuk-heading-m">For advice about teaching</h4>
 <p class="govuk-body">For advice about teaching or teacher training you can call <a href="https://getintoteaching.education.gov.uk/">Get into Teaching</a> on Freephone 0800 389 2500 or chat to an adviser using their <a href="https://ta-chat.education.gov.uk/chat/chatstart.aspx?domain=www.education.gov.uk&department=GetIntoTeaching%27,%27new_win%27,%27width=0,height=0%27);return%20false;%22&SID=1">online chat service</a> between 8am and 8pm, Monday to Friday.</p>


### PR DESCRIPTION
Give context about where those contact details are and indicate that the link stays on the same page.