### PR TITLE
Extend basic print styles

### DIFF
--- a/src/Assets/Styles/site.scss
+++ b/src/Assets/Styles/site.scss
@@ -131,3 +131,11 @@ $govuk-global-styles: true;
   font-weight: bold;
   margin-bottom: govuk-spacing(1);
 }
+
+@media print {
+  .govuk-phase-banner,
+  .govuk-footer,
+  .govuk-back-link {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Context
Add more details beyond the ones from govuk-frontend

### Changes proposed in this pull request
Hide phase banner, back link and footer for print only

### Guidance to review
![screen shot 2018-10-01 at 12 55 07](https://user-images.githubusercontent.com/3071606/46287062-4094ac00-c579-11e8-97ff-5557a0c0010f.png)