### PR TITLE
Add and use Google Analytics events in forms

### DIFF
--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -1,0 +1,39 @@
+// How to use:
+// 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
+// 2. Attach `data-ga-event-form-input="Helpful Label" to <input>s of type checkbox or radio
+// When users click on [type='submit'] in the form, an analytics event is triggered with the
+// namespace followed by the specified labels of the checked inputs.
+const dataAttrForm = "data-ga-event-form"
+const dataAttrInput = "data-ga-event-form-input"
+
+const triggerAnalyticsEvent = (namespace, label) => {
+  ga("send", "event", {
+    eventCategory: "Form: " + namespace,
+    eventAction: label,
+    transport: "beacon"
+  })
+}
+
+const attachAnalyticsToForm = $form => {
+  const namespace = $form.getAttribute(dataAttrForm)
+  const $submitBtn = $form.querySelector('[type="submit"]')
+
+  $submitBtn.addEventListener("click", () => {
+    const $checkedInputs = $form.querySelectorAll("[" + dataAttrInput + "]:checked")
+    const values = []
+
+    for (let j = 0; j < $checkedInputs.length; j++) {
+      values.push($checkedInputs[j].getAttribute(dataAttrInput))
+    }
+
+    triggerAnalyticsEvent(namespace, values.join(", "))
+  })
+}
+
+if (typeof ga !== "undefined") {
+  const $forms = document.querySelectorAll("[" + dataAttrForm + "]")
+
+  for (let i = 0; i < $forms.length; i++) {
+    attachAnalyticsToForm($forms[i])
+  }
+}

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -3,6 +3,7 @@ import CookieMessage from './Javascript/cookie-message';
 import BackLink from './Javascript/back-link';
 import Accordion from './Javascript/accordion';
 import Toggle from './Javascript/toggle';
+import './Javascript/analytics.js';
 import './Javascript/typeahead.jquery.js';
 import './Styles/site.scss';
 

--- a/src/Views/Filter/Funding.cshtml
+++ b/src/Views/Filter/Funding.cshtml
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <form action='@Url.Action("Funding", "Filter", Model.ToRouteValues())' method="POST">
+  <form action='@Url.Action("Funding", "Filter", Model.ToRouteValues())' method="POST" data-ga-event-form="Salary">
     <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
         <h1 class="govuk-heading-xl">Find courses that pay a salary</h1>
@@ -33,13 +33,13 @@
           <div class="govuk-form-group @(errors.HasError("applyFilter") ? "govuk-form-group--error" : "")" id="applyFilter-container">
             <div class="govuk-radios" data-module="radios">
               <div class="govuk-radios__item">
-                <input id="applyFilter-all" class="govuk-radios__input" type="radio" name="applyFilter" value="false" checked="@(Model.SelectedFunding == FundingOption.All)">
+                <input id="applyFilter-all" class="govuk-radios__input" type="radio" name="applyFilter" value="false" checked="@(Model.SelectedFunding == FundingOption.All)" data-ga-event-form-input="All courses with/without a salary">
                 <label for="applyFilter-all" class="govuk-label govuk-radios__label">
                   All courses (with or without a salary)
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="applyFilter-some" class="govuk-radios__input" type="radio" name="applyFilter" value="true" checked="@(errors.HasError("funding ") || (Model.SelectedFunding != null && Model.SelectedFunding != FundingOption.All))">
+                <input id="applyFilter-some" class="govuk-radios__input" type="radio" name="applyFilter" value="true" checked="@(errors.HasError("funding ") || (Model.SelectedFunding != null && Model.SelectedFunding != FundingOption.All))" data-ga-event-form-input="Only courses with a salary">
                 <label for="applyFilter-some" class="govuk-label govuk-radios__label">
                   Only courses that come with a salary
                 </label>

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -24,7 +24,7 @@ else
     <div class="govuk-grid-column-two-thirds">
       @Html.Partial("Error", Model.Errors)
 
-      <form action='@Url.Action(isInWizard ? "LocationWizard" : "Location", "Filter", Model.FilterModel.ToRouteValues())' method="POST">
+      <form action='@Url.Action(isInWizard ? "LocationWizard" : "Location", "Filter", Model.FilterModel.ToRouteValues())' method="POST" data-ga-event-form="Location">
         <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
@@ -38,7 +38,7 @@ else
 
             <div class="govuk-radios" data-module="radios">
               <div class="govuk-radios__item">
-                <input id="location-Set" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.Yes)" checked="@(Model.FilterModel.LocationOption == LocationOption.Yes)" data-aria-controls="lq-container">
+                <input id="location-Set" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.Yes)" checked="@(Model.FilterModel.LocationOption == LocationOption.Yes)" data-aria-controls="lq-container" data-ga-event-form-input="By postcode/city">
                 <label for="location-Set" class="govuk-label govuk-radios__label">
                   By postcode, town or city
                 </label>
@@ -72,14 +72,14 @@ else
               </div>
 
               <div class="govuk-radios__item">
-                <input id="location-Unset" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.No)" checked="@(Model.FilterModel.LocationOption == LocationOption.No)">
+                <input id="location-Unset" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.No)" checked="@(Model.FilterModel.LocationOption == LocationOption.No)" data-ga-event-form-input="Across England">
                 <label for="location-Unset" class="govuk-label govuk-radios__label">Across England</label>
               </div>
 
               <div class="govuk-radios__divider">or</div>
 
               <div class="govuk-radios__item">
-                <input id="location-Specific" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.Specific)" checked="@(Model.FilterModel.LocationOption == LocationOption.Specific)" data-aria-controls="query-container">
+                <input id="location-Specific" class="govuk-radios__input" type="radio" name="l" value="@((int)LocationOption.Specific)" checked="@(Model.FilterModel.LocationOption == LocationOption.Specific)" data-aria-controls="query-container" data-ga-event-form-input="By school/provider">
                 <label for="location-Specific" class="govuk-label govuk-radios__label">
                   By school, university or other training provider
                 </label>

--- a/src/Views/Filter/Qualification.cshtml
+++ b/src/Views/Filter/Qualification.cshtml
@@ -9,7 +9,7 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action='@Url.Action("Qualification", "Filter", Model.ToRouteValues())' method="POST">
+      <form action='@Url.Action("Qualification", "Filter", Model.ToRouteValues())' method="POST" data-ga-event-form="Qualification">
         <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-heading-xl">What you will get</h1>
@@ -18,7 +18,7 @@
           <div class="govuk-form-group">
             <div class="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
-                <input id="applyFilter-qts-only" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.QtsOnly" checked="@Model.qualification.Any(x => x == QualificationOption.QtsOnly)">
+                <input id="applyFilter-qts-only" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.QtsOnly" checked="@Model.qualification.Any(x => x == QualificationOption.QtsOnly)" data-ga-event-form-input="QTS only">
                 <label for="applyFilter-qts-only" class="govuk-label govuk-checkboxes__label">
                   <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                     QTS only
@@ -32,7 +32,7 @@
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input id="applyFilter-pgce-pgde-with-qts" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.PgdePgceWithQts" checked="@Model.qualification.Any(x => x == QualificationOption.PgdePgceWithQts)">
+                <input id="applyFilter-pgce-pgde-with-qts" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.PgdePgceWithQts" checked="@Model.qualification.Any(x => x == QualificationOption.PgdePgceWithQts)" data-ga-event-form-input="PGCE / PGDE with QTS">
                 <label for="applyFilter-pgce-pgde-with-qts" class="govuk-label govuk-checkboxes__label">
                   <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                     PGCE (or PGDE) with QTS
@@ -52,7 +52,7 @@
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input id="applyFilter-other" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.Other" checked="@Model.qualification.Any(x => x == QualificationOption.Other)">
+                <input id="applyFilter-other" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.Other" checked="@Model.qualification.Any(x => x == QualificationOption.Other)" data-ga-event-form-input="Further Education">
                 <label for="applyFilter-other" class="govuk-label govuk-checkboxes__label">
                   <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                     Further Education (PGCE or PGDE without QTS)

--- a/src/Views/Filter/StudyType.cshtml
+++ b/src/Views/Filter/StudyType.cshtml
@@ -13,7 +13,7 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action='@Url.Action("StudyType", "Filter", Model.ToRouteValues())' method="POST">
+      <form action='@Url.Action("StudyType", "Filter", Model.ToRouteValues())' method="POST" data-ga-event-form="Study Type">
         <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
           <legend>
             <h1 class="govuk-heading-xl">Study type</h1>
@@ -22,7 +22,7 @@
           <div class="govuk-form-group">
             <div class="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
-                <input id="applyFilter-includefulltime" class="govuk-checkboxes__input" type="checkbox" name="fulltime" value="true" checked="@(Model.fulltime || !Model.parttime)">
+                <input id="applyFilter-includefulltime" class="govuk-checkboxes__input" type="checkbox" name="fulltime" value="true" checked="@(Model.fulltime || !Model.parttime)" data-ga-event-form-input="Full time">
                 <label for="applyFilter-includefulltime" class="govuk-label govuk-checkboxes__label">
                   <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">Full time (12 months)</span>
                   <span>
@@ -32,7 +32,7 @@
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input id="applyFilter-includeparttime" class="govuk-checkboxes__input" type="checkbox" name="parttime" value="true" checked="@(Model.parttime || !Model.fulltime)">
+                <input id="applyFilter-includeparttime" class="govuk-checkboxes__input" type="checkbox" name="parttime" value="true" checked="@(Model.parttime || !Model.fulltime)" data-ga-event-form-input="Part time">
                 <label for="applyFilter-includeparttime" class="govuk-label govuk-checkboxes__label">
                   <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">Part time (18 &ndash; 24 months)</span>
                   <span>

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -24,74 +24,72 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       @Html.Partial("Error", errors)
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-heading-xl">Find courses by subject</h1>
-          </legend>
-          <p class="govuk-body">Select the subjects you want to teach.</p>
-          <h2 class="govuk-heading-m">Get financial support</h2>
-          <p class="govuk-body">Most courses charge a fee. You can get financial support to help with the costs of your course. The financial support options available to you will depend on the subject you choose.</p>
-          <p class="govuk-body">Find out more about <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans">postgraduate loans</a>, <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview">bursaries and scholarships</a> and <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject">funding by subject</a> on Get into Teaching.</p>
-          <form action='@Url.Action(isInWizard ? "SubjectWizard" : "Subject", "Filter", Model.FilterModel.WithoutSubjects().ToRouteValues())' method="POST" id="subjects-container">
-            <div class="accordion" data-module="accordion">
-              @foreach (var area in Model.SubjectAreas) {
-                <div class="@(" accordion-section " + (@area.Subjects.Any(subject => selected.Contains(subject.Id)) ? "accordion-section--expanded" : " "))">
-                  <div class="accordion-section-header">@area.Name</div>
-                  <div class="accordion-section-body">
-                    <div class="govuk-checkboxes">
-                      @foreach (var subject in area.Subjects.OrderBy(x => x.Name)) {
-                        <div class="govuk-checkboxes__item">
-                          <input id="@("subject-" + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input">
-                          <label for="@("subject-" + subject.Id)" class="govuk-label govuk-checkboxes__label">
-                            <span class="govuk-checkboxes__label_text">
-                              @subject.Name
-                            </span>
-                            @{
-                              string txt = null;
-                              if (subject.Funding?.Scholarship != null && subject.Funding?.BursaryFirst != null)
-                              {
-                                  txt = $"Scholarships of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.Scholarship.Value)} and bursaries of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.BursaryFirst.Value)} are available";
-                              }
-                              else if (subject.Funding?.Scholarship != null)
-                              {
-                                  txt = $"Scholarships of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.Scholarship.Value)} are available";
-                              }
-                              else if (subject.Funding?.BursaryFirst != null)
-                              {
-                                 txt = $"Bursaries of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.BursaryFirst.Value)} available";
-                              }
-
-                              if (txt != null && subject.Funding?.EarlyCareerPayments != null)
-                              {
-                                  txt += $", with early career payments of £5,000 each in your third and fifth year of teaching (£7,500 each in some areas of England).";
-                              }
-                              else if (txt != null)
-                              {
-                                  txt += ".";
-                              }
-                            }
-                            <span class="govuk-!-display-block">@txt</span>
-                          </label>
-                          @if (subject.IsSubjectKnowledgeEnhancementAvailable)
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-heading-xl">Find courses by subject</h1>
+        </legend>
+        <p class="govuk-body">Select the subjects you want to teach.</p>
+        <h2 class="govuk-heading-m">Get financial support</h2>
+        <p class="govuk-body">Most courses charge a fee. You can get financial support to help with the costs of your course. The financial support options available to you will depend on the subject you choose.</p>
+        <p class="govuk-body">Find out more about <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans">postgraduate loans</a>, <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview">bursaries and scholarships</a> and <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject">funding by subject</a> on Get into Teaching.</p>
+        <form action='@Url.Action(isInWizard ? "SubjectWizard" : "Subject", "Filter", Model.FilterModel.WithoutSubjects().ToRouteValues())' method="POST" id="subjects-container">
+          <div class="accordion govuk-form-group" data-module="accordion">
+            @foreach (var area in Model.SubjectAreas) {
+              <div class="@(" accordion-section " + (@area.Subjects.Any(subject => selected.Contains(subject.Id)) ? "accordion-section--expanded" : " "))">
+                <div class="accordion-section-header">@area.Name</div>
+                <div class="accordion-section-body">
+                  <div class="govuk-checkboxes">
+                    @foreach (var subject in area.Subjects.OrderBy(x => x.Name)) {
+                      <div class="govuk-checkboxes__item">
+                        <input id="@("subject-" + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input">
+                        <label for="@("subject-" + subject.Id)" class="govuk-label govuk-checkboxes__label">
+                          <span class="govuk-checkboxes__label_text">
+                            @subject.Name
+                          </span>
+                          @{
+                            string txt = null;
+                            if (subject.Funding?.Scholarship != null && subject.Funding?.BursaryFirst != null)
                             {
-                              <p class="govuk-body">
-                                You can@(subject.Funding?.Scholarship != null || subject.Funding?.BursaryFirst != null ? " also " : " ")take a <a href="https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses">subject knowledge enhancement (SKE) course</a>.
-                              </p>
+                                txt = $"Scholarships of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.Scholarship.Value)} and bursaries of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.BursaryFirst.Value)} are available";
                             }
-                        </div>
-                      }
-                    </div>
+                            else if (subject.Funding?.Scholarship != null)
+                            {
+                                txt = $"Scholarships of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.Scholarship.Value)} are available";
+                            }
+                            else if (subject.Funding?.BursaryFirst != null)
+                            {
+                                txt = $"Bursaries of {String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", subject.Funding.BursaryFirst.Value)} available";
+                            }
+
+                            if (txt != null && subject.Funding?.EarlyCareerPayments != null)
+                            {
+                                txt += $", with early career payments of £5,000 each in your third and fifth year of teaching (£7,500 each in some areas of England).";
+                            }
+                            else if (txt != null)
+                            {
+                                txt += ".";
+                            }
+                          }
+                          <span class="govuk-!-display-block">@txt</span>
+                        </label>
+                        @if (subject.IsSubjectKnowledgeEnhancementAvailable)
+                          {
+                            <p class="govuk-body">
+                              You can@(subject.Funding?.Scholarship != null || subject.Funding?.BursaryFirst != null ? " also " : " ")take a <a href="https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses">subject knowledge enhancement (SKE) course</a>.
+                            </p>
+                          }
+                      </div>
+                    }
                   </div>
                 </div>
-              }
-            </div>
-          </fieldset>
-        </div>
-        <div class="govuk-form-group">
-          <input class="govuk-button" type="submit" value="@(isInWizard ? "Continue" : "Find courses")" role="button">
-        </div>
-      </form>
+              </div>
+            }
+          </div>
+          <div class="govuk-form-group">
+            <input class="govuk-button" type="submit" value="@(isInWizard ? "Continue" : "Find courses")" role="button">
+          </div>
+        </form>
+      </fieldset>
     </div>
   </div>
 </main>

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -32,7 +32,7 @@
         <h2 class="govuk-heading-m">Get financial support</h2>
         <p class="govuk-body">Most courses charge a fee. You can get financial support to help with the costs of your course. The financial support options available to you will depend on the subject you choose.</p>
         <p class="govuk-body">Find out more about <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans">postgraduate loans</a>, <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview">bursaries and scholarships</a> and <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject">funding by subject</a> on Get into Teaching.</p>
-        <form action='@Url.Action(isInWizard ? "SubjectWizard" : "Subject", "Filter", Model.FilterModel.WithoutSubjects().ToRouteValues())' method="POST" id="subjects-container">
+        <form action='@Url.Action(isInWizard ? "SubjectWizard" : "Subject", "Filter", Model.FilterModel.WithoutSubjects().ToRouteValues())' method="POST" id="subjects-container" data-ga-event-form="Subject">
           <div class="accordion govuk-form-group" data-module="accordion">
             @foreach (var area in Model.SubjectAreas) {
               <div class="@(" accordion-section " + (@area.Subjects.Any(subject => selected.Contains(subject.Id)) ? "accordion-section--expanded" : " "))">
@@ -41,7 +41,7 @@
                   <div class="govuk-checkboxes">
                     @foreach (var subject in area.Subjects.OrderBy(x => x.Name)) {
                       <div class="govuk-checkboxes__item">
-                        <input id="@("subject-" + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input">
+                        <input id="@("subject-" + subject.Id)" name="SelectedSubjects" type="checkbox" checked="@selected.Contains(subject.Id)" value="@(subject.Id)" class="govuk-checkboxes__input" data-ga-event-form-input="@(subject.Name)">
                         <label for="@("subject-" + subject.Id)" class="govuk-label govuk-checkboxes__label">
                           <span class="govuk-checkboxes__label_text">
                             @subject.Name


### PR DESCRIPTION
### Context

We want to identify interaction issues using analytics.

### Changes proposed in this pull request

This is a self-initialising JS module that will hook into forms which have specific data attributes.

The following forms will now send GA events when submitted:

- Location
- Subjects
- Study Type
- Qualification
- Salary

### Example analytics output

<img width="1143" alt="screenshot 2018-10-02 at 16 19 25" src="https://user-images.githubusercontent.com/1650875/46358898-f1757680-c65f-11e8-8012-1cf5a1aa497e.png">
