### PR TITLE
Track external links and in-page navigation

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -66,7 +66,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="course-contents govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-m">Contents</h2>
-          <ul class="govuk-list govuk-list--dash">
+          <ul class="govuk-list govuk-list--dash" data-ga-event-navigation="Course Contents">
             @if (Model.PreviewMode || Model.HasSection(CourseDetailsSections.AboutTheCourse) || Model.ShowMinimumAboutCourseSection)
             {
               <li><a href="#section-about">About the course</a></li>

--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -1,39 +1,43 @@
-// How to use:
-// 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
-// 2. Attach `data-ga-event-form-input="Helpful Label" to <input>s of type checkbox or radio
-// When users click on [type='submit'] in the form, an analytics event is triggered with the
-// namespace followed by the specified labels of the checked inputs.
-const dataAttrForm = "data-ga-event-form"
-const dataAttrInput = "data-ga-event-form-input"
+const initFormAnalytics = () => {
+  // How to use:
+  // 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
+  // 2. Attach `data-ga-event-form-input="Helpful Label" to <input>s of type checkbox or radio
+  // When users click on [type='submit'] in the form, an analytics event is triggered with the
+  // namespace followed by the specified labels of the checked inputs.
+  const dataAttrForm = "data-ga-event-form"
+  const dataAttrInput = "data-ga-event-form-input"
 
-const triggerAnalyticsEvent = (namespace, label) => {
-  ga("send", "event", {
-    eventCategory: "Form: " + namespace,
-    eventAction: label,
-    transport: "beacon"
-  })
-}
+  const triggerAnalyticsEvent = (category, action) => {
+    ga("send", "event", {
+      eventCategory: category,
+      eventAction: action,
+      transport: "beacon"
+    })
+  }
 
-const attachAnalyticsToForm = $form => {
-  const namespace = $form.getAttribute(dataAttrForm)
-  const $submitBtn = $form.querySelector('[type="submit"]')
+  const attachAnalyticsToForm = $form => {
+    const namespace = $form.getAttribute(dataAttrForm)
+    const $submitBtn = $form.querySelector('[type="submit"]')
 
-  $submitBtn.addEventListener("click", () => {
-    const $checkedInputs = $form.querySelectorAll("[" + dataAttrInput + "]:checked")
-    const values = []
+    $submitBtn.addEventListener("click", () => {
+      const $checkedInputs = $form.querySelectorAll("[" + dataAttrInput + "]:checked")
+      const values = []
 
-    for (let j = 0; j < $checkedInputs.length; j++) {
-      values.push($checkedInputs[j].getAttribute(dataAttrInput))
-    }
+      for (let j = 0; j < $checkedInputs.length; j++) {
+        values.push($checkedInputs[j].getAttribute(dataAttrInput))
+      }
 
-    triggerAnalyticsEvent(namespace, values.join(", "))
-  })
-}
+      triggerAnalyticsEvent("Form: " + namespace, values.join(", "))
+    })
+  }
 
-if (typeof ga !== "undefined") {
   const $forms = document.querySelectorAll("[" + dataAttrForm + "]")
 
   for (let i = 0; i < $forms.length; i++) {
     attachAnalyticsToForm($forms[i])
   }
+}
+
+if (typeof ga !== "undefined") {
+  initFormAnalytics()
 }

--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -1,3 +1,11 @@
+const triggerAnalyticsEvent = (category, action) => {
+  ga("send", "event", {
+    eventCategory: category,
+    eventAction: action,
+    transport: "beacon"
+  })
+}
+
 const initFormAnalytics = () => {
   // How to use:
   // 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
@@ -6,14 +14,6 @@ const initFormAnalytics = () => {
   // namespace followed by the specified labels of the checked inputs.
   const dataAttrForm = "data-ga-event-form"
   const dataAttrInput = "data-ga-event-form-input"
-
-  const triggerAnalyticsEvent = (category, action) => {
-    ga("send", "event", {
-      eventCategory: category,
-      eventAction: action,
-      transport: "beacon"
-    })
-  }
 
   const attachAnalyticsToForm = $form => {
     const namespace = $form.getAttribute(dataAttrForm)
@@ -38,6 +38,21 @@ const initFormAnalytics = () => {
   }
 }
 
+const initExternalLinkAnalytics = () => {
+  const externalLinkSelector = 'a[href^="http"]:not(a[href*="' + window.location.hostname + '"])'
+
+  const trackClickEvent = event => {
+    triggerAnalyticsEvent("External Link Clicked", event.target.getAttribute("href"))
+  }
+
+  const $links = document.querySelectorAll(externalLinkSelector)
+
+  for (let i = 0; i < $links.length; i++) {
+    $links[i].addEventListener("click", trackClickEvent)
+  }
+}
+
 if (typeof ga !== "undefined") {
   initFormAnalytics()
+  initExternalLinkAnalytics()
 }

--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -8,10 +8,13 @@ const triggerAnalyticsEvent = (category, action) => {
 
 const initFormAnalytics = () => {
   // How to use:
+  //
   // 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
   // 2. Attach `data-ga-event-form-input="Helpful Label" to <input>s of type checkbox or radio
+  //
   // When users click on [type='submit'] in the form, an analytics event is triggered with the
   // namespace followed by the specified labels of the checked inputs.
+
   const dataAttrForm = "data-ga-event-form"
   const dataAttrInput = "data-ga-event-form-input"
 
@@ -39,6 +42,8 @@ const initFormAnalytics = () => {
 }
 
 const initExternalLinkAnalytics = () => {
+  // This will attach event listeners to all links with hrefs that point to external resource.
+
   const externalLinkSelector = 'a[href^="http"]:not(a[href*="' + window.location.hostname + '"])'
 
   const trackClickEvent = event => {
@@ -52,7 +57,39 @@ const initExternalLinkAnalytics = () => {
   }
 }
 
+const initNavigationAnalytics = () => {
+  // How to use:
+  //
+  // 1. Attach `data-ga-event-navigation="Helpful Namespace"` to a container that has links
+  //
+  // When users click on a[href] in the container, an analytics event is triggered with the
+  // namespace followed by the href.
+
+  const dataAttrNav = "data-ga-event-navigation"
+
+  const attachAnalyticsToNav = $nav => {
+    const namespace = $nav.getAttribute(dataAttrNav)
+
+    const trackClickEvent = event => {
+      triggerAnalyticsEvent(namespace + " Navigation Link Clicked", event.target.getAttribute("href"))
+    }
+
+    const $links = $nav.querySelectorAll("a[href]")
+
+    for (let i = 0; i < $links.length; i++) {
+      $links[i].addEventListener("click", trackClickEvent)
+    }
+  }
+
+  const $navs = document.querySelectorAll("[" + dataAttrNav + "]")
+
+  for (let i = 0; i < $navs.length; i++) {
+    attachAnalyticsToNav($navs[i])
+  }
+}
+
 if (typeof ga !== "undefined") {
   initFormAnalytics()
   initExternalLinkAnalytics()
+  initNavigationAnalytics()
 }


### PR DESCRIPTION
### Context

To allow the team to design with data and identify interaction issues.

### Changes proposed in this pull request

This is a stripped down version of the [external link tracker from govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/external-link-tracker.js). A notable difference is this module doesn't currently work with links that are dynamically inserted into the DOM after page load. Because our application is fully server-side rendered at the moment, this can be remedied later if necessary.

This also wraps the form analytics into its own initialiser function, which can help later if we decide to split these modules into separate files.

Also included is in-page navigation tracking.

Best reviewed with `?w=1` to ignore whitespace.