### PR TITLE
Update the Google Geocoder API key

### DIFF
--- a/tests/Unit.Tests/Services/Geocoder.Tests.cs
+++ b/tests/Unit.Tests/Services/Geocoder.Tests.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         [SetUp]
         public void SetUp()
         {
-            geocoder = new Geocoder("AIzaSyC6CQg447XEuO95H6aIUkMKVqEeFwrboUk", new HttpClient());
+            geocoder = new Geocoder("AIzaSyBytKgqIJS_7wysO7ZFSgUb0I549SmX3yw", new HttpClient());
         }
 
         [Test]


### PR DESCRIPTION
This should fix the tests on CI, due to the fact that the previous key has been rate limited.