### PR TITLE
Make search results easier to understand

### DIFF
--- a/src/Assets/Styles/patterns/_definition-list.scss
+++ b/src/Assets/Styles/patterns/_definition-list.scss
@@ -42,4 +42,11 @@
     content: ":";
     display: inline-block;
   }
+
+  &__hint {
+    @include govuk-font($size: 16, $weight: normal);
+    color: $govuk-secondary-text-colour;
+    display: block;
+    margin-bottom: govuk-space(1);
+  }
 }

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -29,7 +29,7 @@
           <dt class="govuk-list--description__label">Distance</dt>
           <dd>
             @item.Distance.FormattedDistance()
-            <span style="color: #6f777b; display: block; font-size: 16px; margin-bottom: 5px;">
+            <span class="govuk-list--description__hint">
               to the training provider or their nearest training location
             </span>
           </dd>

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -25,26 +25,31 @@
         <a href='@Url.Action("Index", "Course", new {courseCode = item.ProgrammeCode, providerCode = item.Provider.ProviderCode})' class="link">@item.Name with @item.Provider.Name</a>
       </h3>
       <dl class="govuk-list--description">
+        @if (item.Distance != null) {
+          <dt class="govuk-list--description__label">Distance</dt>
+          <dd>
+            @item.Distance.FormattedDistance()
+            <span style="color: #6f777b; display: block; font-size: 16px; margin-bottom: 5px;">
+              to the training provider or their nearest training location
+            </span>
+          </dd>
+        }
         @if(!string.IsNullOrEmpty(item.Mod) && item.Mod.Length > 1)
         {
           <dt class="govuk-list--description__label">Course offered</dt>
           <dd>@item.Mod</dd>
+        }
+        <dt class="govuk-list--description__label">Financial support</dt>
+        <dd>@item.FundingOptions()</dd>
+        @if (item.Distance == null && item.ProviderLocation != null) {
+          <dt class="govuk-list--description__label">Address</dt>
+          <dd>@item.ProviderLocation.Address.Replace("\n", ", ")</dd>
         }
         @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name) && item.Provider.Name != item.AccreditingProvider?.Name)
         {
           <dt class="govuk-list--description__label">Accredited provider</dt>
           <dd>@item.AccreditingProvider.Name</dd>
         }
-        @if (item.Distance != null) {
-          <dt class="govuk-list--description__label">Distance</dt>
-          <dd>@item.Distance.FormattedDistance()</dd>
-        }
-        @if (item.ProviderLocation != null) {
-          <dt class="govuk-list--description__label">Address</dt>
-          <dd>@item.ProviderLocation.Address.Replace("\n", ", ")</dd>
-        }
-        <dt class="govuk-list--description__label">Financial support</dt>
-        <dd>@item.FundingOptions()</dd>
       </dl>
     </li>
   }

--- a/src/Views/Shared/SortBy.cshtml
+++ b/src/Views/Shared/SortBy.cshtml
@@ -23,7 +23,7 @@
     }
 
     @if (!Model.FilterModel.DisplayAsMap && string.IsNullOrWhiteSpace(Model.FilterModel.query)) {
-      <div class="govuk-grid-column-two-thirds">
+      <div class="@(Model.MapsEnabled ? "govuk-grid-column-two-thirds": "govuk-grid-column-full")">
         <form action='@Url.Action("SortBy", "Results", Model.FilterModel.ToRouteValues())' class="govuk-form" method="POST">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-label--inline sortedby-label" for="sortby">Sorted by</label>


### PR DESCRIPTION
### Context

A temporary solution until we surface the address we matched when searching.

### Changes proposed in this pull request

* Give context to the distance so it's clear what it's to
* Hide confusing address
* Move accredited provider away from distance, the two can also be conflated although for most courses people will probably need to travel to the accredited provider at some point

### Guidance to review

* Needs to be checked and run locally
* Styles need to be moved into Sass
* The address should still show on Provider and Across England searches

Should look like:
![screen shot 2018-10-05 at 14 05 57](https://user-images.githubusercontent.com/319055/46537068-473c5f80-c8a8-11e8-876d-7ee09d6f6395.png)


