### PR TITLE
Use API client 0.10.2 in order to show DistanceAddress

### DIFF
--- a/shared/SearchAndCompareUi.Shared.csproj
+++ b/shared/SearchAndCompareUi.Shared.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.1-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
   </ItemGroup>
 

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.1-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -41,9 +41,9 @@
         }
         <dt class="govuk-list--description__label">Financial support</dt>
         <dd>@item.FundingOptions()</dd>
-        @if (item.Distance == null && item.ProviderLocation != null) {
+        @if (item.DistanceAddress != null || item.ProviderLocation != null) {
           <dt class="govuk-list--description__label">Address</dt>
-          <dd>@item.ProviderLocation.Address.Replace("\n", ", ")</dd>
+          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
         }
         @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name) && item.Provider.Name != item.AccreditingProvider?.Name)
         {

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.1-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

When a user searches by location, we match on the closest location but show the default provider address, causing confusion. So we want to show the address we matched on in the UI

### Changes proposed in this pull request

Use the newly introduced DistanceAddress in search results, when present 

### Guidance to review

See https://github.com/DFE-Digital/search-and-compare-api/pull/76

No unit tests because it's all in Razor


