### PR TITLE
Fix invalid js selector

### DIFF
--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -44,7 +44,7 @@ const initFormAnalytics = () => {
 const initExternalLinkAnalytics = () => {
   // This will attach event listeners to all links with hrefs that point to external resource.
 
-  const externalLinkSelector = 'a[href^="http"]:not(a[href*="' + window.location.hostname + '"])'
+  const externalLinkSelector = 'a[href^="http"]:not([href*="' + window.location.hostname + '"])'
 
   const trackClickEvent = event => {
     triggerAnalyticsEvent("External Link Clicked", event.target.getAttribute("href"))


### PR DESCRIPTION
### Context
We had to switch of GA on prod because this error was causing all JS to stop working

### Changes proposed in this pull request
Fix invalid selector, the extra `a`

### Guidance to review
Ensure GA is enabled and check for console errors
