### PR TITLE
 Rearrange addresses in search results

### DIFF
--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -35,7 +35,7 @@
           </dd>
           if (item.DistanceAddress != null) {
             <dt class="govuk-list--description__label">Nearest address</dt>
-            <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
+            <dd>@(item.DistanceAddress.Replace("\n", ", "))</dd>
           }
         }
         @if(!string.IsNullOrEmpty(item.Mod) && item.Mod.Length > 1)
@@ -52,7 +52,7 @@
         }
         @if (item.DistanceAddress == null && item.ProviderLocation != null) {
           <dt class="govuk-list--description__label">Main address</dt>
-          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
+          <dd>@(item.ProviderLocation.Address.Replace("\n", ", "))</dd>
         }
       </dl>
     </li>

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -34,6 +34,10 @@
             </span>
           </dd>
         }
+        @if (item.DistanceAddress != null || item.ProviderLocation != null) {
+          <dt class="govuk-list--description__label">Address</dt>
+          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
+        }
         @if(!string.IsNullOrEmpty(item.Mod) && item.Mod.Length > 1)
         {
           <dt class="govuk-list--description__label">Course offered</dt>
@@ -41,10 +45,6 @@
         }
         <dt class="govuk-list--description__label">Financial support</dt>
         <dd>@item.FundingOptions()</dd>
-        @if (item.DistanceAddress != null || item.ProviderLocation != null) {
-          <dt class="govuk-list--description__label">Address</dt>
-          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
-        }
         @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name) && item.Provider.Name != item.AccreditingProvider?.Name)
         {
           <dt class="govuk-list--description__label">Accredited provider</dt>

--- a/src/Views/Shared/Display/List.cshtml
+++ b/src/Views/Shared/Display/List.cshtml
@@ -33,10 +33,10 @@
               to the training provider or their nearest training location
             </span>
           </dd>
-        }
-        @if (item.DistanceAddress != null || item.ProviderLocation != null) {
-          <dt class="govuk-list--description__label">Address</dt>
-          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
+          if (item.DistanceAddress != null) {
+            <dt class="govuk-list--description__label">Nearest address</dt>
+            <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
+          }
         }
         @if(!string.IsNullOrEmpty(item.Mod) && item.Mod.Length > 1)
         {
@@ -49,6 +49,10 @@
         {
           <dt class="govuk-list--description__label">Accredited provider</dt>
           <dd>@item.AccreditingProvider.Name</dd>
+        }
+        @if (item.DistanceAddress == null && item.ProviderLocation != null) {
+          <dt class="govuk-list--description__label">Main address</dt>
+          <dd>@((item.DistanceAddress ?? item.ProviderLocation.Address).Replace("\n", ", "))</dd>
         }
       </dl>
     </li>


### PR DESCRIPTION
### Context

Now showing campus/provider address in results list.

### Changes proposed in this pull request

Move address next to distance if it's a distance based result

### Location search result

![7 vm_337](https://user-images.githubusercontent.com/19378/46606576-91fee700-caf5-11e8-936f-4d6aff809543.png)

### Non location result

![7 vm_336](https://user-images.githubusercontent.com/19378/46606558-827f9e00-caf5-11e8-947b-47a543dd1ccc.png)
