### PR TITLE
Add root level package json

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,15 @@
   "env": {
     "API_URI": {
       "required": true
+    },
+    "FEATURE_MAPS": {
+      "required": true
+    },
+    "ApiKeys__GoogleMaps": {
+      "required": true
+    },
+    "ApiKeys__GoogleMapsStatic": {
+      "required": true
     }
   },
   "formation": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dfe-search-and-compare-ui",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DFE-Digital/search-and-compare-ui.git"
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
This is required for heroku to build review apps whenever a pull request is raised. Heroku uses the nodejs buildpack to enable webpack to compile on build so it requires a package.json file at root level.

### Context
Fix up heroku review apps

### Changes proposed in this pull request
Add root level package.json

### Guidance to review
Did this PR deploy 👀 
