### PR TITLE
Add JS unit tests for Analytics

### DIFF
--- a/src/Assets/Javascript/__snapshots__/analytics.test.js.snap
+++ b/src/Assets/Javascript/__snapshots__/analytics.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Analytics initExternalLinkAnalytics triggers correct GA events when users click on external links 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "http://example.com",
+      "eventCategory": "External Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "https://google.com",
+      "eventCategory": "External Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+]
+`;
+
+exports[`Analytics initFormAnalytics triggers correct GA event when users submit with checked checkboxes 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "A ticked item, Another ticked item",
+      "eventCategory": "Form: Some form",
+      "transport": "beacon",
+    },
+  ],
+]
+`;
+
+exports[`Analytics initNavigationAnalytics triggers correct GA events when users click on navigation links 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "#about",
+      "eventCategory": "Some navigation Navigation Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "http://example.com",
+      "eventCategory": "Some navigation Navigation Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+]
+`;

--- a/src/Assets/Javascript/analytics.js
+++ b/src/Assets/Javascript/analytics.js
@@ -6,7 +6,7 @@ const triggerAnalyticsEvent = (category, action) => {
   })
 }
 
-const initFormAnalytics = () => {
+export const initFormAnalytics = () => {
   // How to use:
   //
   // 1. Attach `data-ga-event-form="Helpful Namespace"` to <form> elements
@@ -41,7 +41,7 @@ const initFormAnalytics = () => {
   }
 }
 
-const initExternalLinkAnalytics = () => {
+export const initExternalLinkAnalytics = () => {
   // This will attach event listeners to all links with hrefs that point to external resource.
 
   const externalLinkSelector = 'a[href^="http"]:not([href*="' + window.location.hostname + '"])'
@@ -57,7 +57,7 @@ const initExternalLinkAnalytics = () => {
   }
 }
 
-const initNavigationAnalytics = () => {
+export const initNavigationAnalytics = () => {
   // How to use:
   //
   // 1. Attach `data-ga-event-navigation="Helpful Namespace"` to a container that has links
@@ -86,10 +86,4 @@ const initNavigationAnalytics = () => {
   for (let i = 0; i < $navs.length; i++) {
     attachAnalyticsToNav($navs[i])
   }
-}
-
-if (typeof ga !== "undefined") {
-  initFormAnalytics()
-  initExternalLinkAnalytics()
-  initNavigationAnalytics()
 }

--- a/src/Assets/Javascript/analytics.test.js
+++ b/src/Assets/Javascript/analytics.test.js
@@ -1,0 +1,67 @@
+import { initFormAnalytics, initExternalLinkAnalytics, initNavigationAnalytics } from "./analytics"
+
+global.ga = jest.fn()
+
+describe("Analytics", () => {
+  afterEach(() => {
+    global.ga.mockClear()
+  })
+
+  describe("initFormAnalytics", () => {
+    beforeEach(() => {
+      // Note: not a <form> because JSDOM throws a fit https://github.com/jsdom/jsdom/issues/1937
+      document.body.innerHTML = `
+        <div data-ga-event-form="Some form">
+          <input type="checkbox" data-ga-event-form-input="A ticked item" checked>
+          <input type="checkbox" data-ga-event-form-input="An unticked item">
+          <input type="checkbox" data-ga-event-form-input="Another ticked item" checked>
+          <input type="submit">
+        </div>
+        `
+      initFormAnalytics()
+    })
+
+    it("triggers correct GA event when users submit with checked checkboxes", () => {
+      document.querySelector("[type=submit]").click()
+      expect(ga.mock.calls).toMatchSnapshot()
+    })
+  })
+
+  describe("initExternalLinkAnalytics", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div>
+          <a href="http://example.com"></a>
+          <a href="https://google.com"></a>
+
+          <a href="http://localhost/foo"></a>
+          <a href="/foo"></a>
+          <a href="#foo"></a>
+        </div>
+        `
+      initExternalLinkAnalytics()
+    })
+
+    it("triggers correct GA events when users click on external links", () => {
+      Array.from(document.querySelectorAll("a")).forEach($el => $el.click())
+      expect(ga.mock.calls).toMatchSnapshot()
+    })
+  })
+
+  describe("initNavigationAnalytics", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div data-ga-event-navigation="Some navigation">
+          <a href="#about"></a>
+          <a href="http://example.com"></a>
+        </div>
+        `
+      initNavigationAnalytics()
+    })
+
+    it("triggers correct GA events when users click on navigation links", () => {
+      Array.from(document.querySelectorAll("a")).forEach($el => $el.click())
+      expect(ga.mock.calls).toMatchSnapshot()
+    })
+  })
+})

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -1,30 +1,30 @@
-import { initAll } from 'govuk-frontend';
-import CookieMessage from './Javascript/cookie-message';
-import BackLink from './Javascript/back-link';
-import Accordion from './Javascript/accordion';
-import Toggle from './Javascript/toggle';
-import './Javascript/analytics.js';
-import './Javascript/map.js';
-import './Javascript/typeahead.jquery.js';
-import './Styles/site.scss';
+import { initAll } from "govuk-frontend"
+import CookieMessage from "./Javascript/cookie-message"
+import BackLink from "./Javascript/back-link"
+import Accordion from "./Javascript/accordion"
+import Toggle from "./Javascript/toggle"
+import "./Javascript/analytics.js"
+import "./Javascript/map.js"
+import "./Javascript/typeahead.jquery.js"
+import "./Styles/site.scss"
 
-initAll();
+initAll()
 
-var $cookieMessage = document.querySelector('[data-module="cookie-message"]');
-new CookieMessage($cookieMessage).init();
+var $cookieMessage = document.querySelector('[data-module="cookie-message"]')
+new CookieMessage($cookieMessage).init()
 
-var $backLink = document.querySelector('[data-module="back-link"]');
-new BackLink($backLink).init();
+var $backLink = document.querySelector('[data-module="back-link"]')
+new BackLink($backLink).init()
 
 var $accordions = document.querySelectorAll('[data-module="accordion"]')
 for (var i = $accordions.length - 1; i >= 0; i--) {
   var $accordion = $accordions[i]
-  var $sections = $accordion.querySelectorAll('.accordion-section')
+  var $sections = $accordion.querySelectorAll(".accordion-section")
   for (var j = $sections.length - 1; j >= 0; j--) {
-    var $section = $sections[j];
+    var $section = $sections[j]
     var sectionContainsCheckedCheckboxes = !!$section.querySelector('.govuk-checkboxes input[type="checkbox"]:checked')
     if (sectionContainsCheckedCheckboxes) {
-      $section.classList.add('accordion-section--expanded')
+      $section.classList.add("accordion-section--expanded")
     }
   }
   try {
@@ -32,43 +32,50 @@ for (var i = $accordions.length - 1; i >= 0; i--) {
   } catch (e) {
     for (var j = $sections.length - 1; j >= 0; j--) {
       var $section = $sections[j]
-      $section.classList.remove('accordion-section--hidden')
-      $section.classList.add('accordion-section--expanded')
+      $section.classList.remove("accordion-section--hidden")
+      $section.classList.add("accordion-section--expanded")
     }
   }
-};
+}
 
 var $toggle = document.querySelectorAll('[data-module="toggle"]')
 for (var i = $toggle.length - 1; i >= 0; i--) {
-  new Toggle($toggle[i]).init();
-};
+  new Toggle($toggle[i]).init()
+}
 
 if (!!$) {
-  $(document).ready(function () {
+  $(document).ready(function() {
     // Turn off jQuery animation
     jQuery.fx.off = true
 
-    $('.typeahead').each(function () {
-      var $this = $(this);
-      var url = $this.data("url");
-      $this.typeahead({
-        minLength: 3,
-        highlight: true
-      }, {
-        name: url.replace(/\//g, "-"),
-        source: function (query, cbSync, cbAsync) {
-          $.get(url, {
-            query: query
-          }, function (res) {
-            cbAsync(res);
-          });
+    $(".typeahead").each(function() {
+      var $this = $(this)
+      var url = $this.data("url")
+      $this.typeahead(
+        {
+          minLength: 3,
+          highlight: true
         },
-        limit: 10
-      });
-    });
+        {
+          name: url.replace(/\//g, "-"),
+          source: function(query, cbSync, cbAsync) {
+            $.get(
+              url,
+              {
+                query: query
+              },
+              function(res) {
+                cbAsync(res)
+              }
+            )
+          },
+          limit: 10
+        }
+      )
+    })
   })
 }
 
-if (process.env.NODE_ENV == 'development') {
-  module.hot.accept();
+if (process.env.NODE_ENV == "development") {
+  module.hot.accept()
 }

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -3,7 +3,7 @@ import CookieMessage from "./Javascript/cookie-message"
 import BackLink from "./Javascript/back-link"
 import Accordion from "./Javascript/accordion"
 import Toggle from "./Javascript/toggle"
-import "./Javascript/analytics.js"
+import { initFormAnalytics, initExternalLinkAnalytics, initNavigationAnalytics } from "./Javascript/analytics.js"
 import "./Javascript/map.js"
 import "./Javascript/typeahead.jquery.js"
 import "./Styles/site.scss"
@@ -74,6 +74,14 @@ if (!!$) {
       )
     })
   })
+}
+
+if (typeof ga !== "undefined") {
+  initFormAnalytics()
+  initExternalLinkAnalytics()
+  initNavigationAnalytics()
+} else {
+  console.log("Google Analytics `window.ga` object not found. Skipping analytics.")
 }
 
 if (process.env.NODE_ENV == "development") {


### PR DESCRIPTION
Slightly refactors the Analytics module so it exports the individual functions.

This test makes liberal use of [Jest snapshots](https://jestjs.io/docs/en/snapshot-testing) to keep it DRY and light.