### PR TITLE
Add search location to map and set zoom level

### DIFF
--- a/src/Assets/Javascript/map.js
+++ b/src/Assets/Javascript/map.js
@@ -5,7 +5,12 @@ const initGoogleMaps = () => {
     scaleControl: false,
     streetViewControl: false,
     rotateControl: false,
-    fullscreenControl: true
+    fullscreenControl: true,
+    zoom: 11,
+    center: {
+      lat: window.search_location[0].lat,
+      lng: window.search_location[0].lng
+    }
   })
 
   const customMarker = {
@@ -17,7 +22,6 @@ const initGoogleMaps = () => {
 
   const locations = window.locations
   const infoWindow = new google.maps.InfoWindow()
-  const bounds = new google.maps.LatLngBounds()
   const markers = []
 
   for (let i = 0, length = locations.length; i < length; i++) {
@@ -56,12 +60,16 @@ const initGoogleMaps = () => {
       })
     }))(marker, data)
 
-    bounds.extend(latLng)
     markers.push(marker)
   }
 
-  map.fitBounds(bounds)
-  map.panToBounds(bounds)
+  const marker = new google.maps.Marker({
+    position: {
+      lat: window.search_location[0].lat,
+      lng: window.search_location[0].lng
+    },
+    map: map
+  });
 }
 
 window.initGoogleMaps = initGoogleMaps

--- a/src/Views/Results/Display/Map.cshtml
+++ b/src/Views/Results/Display/Map.cshtml
@@ -30,11 +30,16 @@
       <dl class="govuk-list--description">
         @if (@courseGroup.Courses.First().Distance != null) {
           <dt class="govuk-list--description__label">Distance</dt>
-          <dd>@courseGroup.Courses.First().Distance.FormattedDistance()</dd>
-        }
-        @if (@courseGroup.Courses.First().ProviderLocation != null) {
+          <dd>
+            @courseGroup.Courses.First().Distance.FormattedDistance()
+            <span class="govuk-list--description__hint">
+              to the training provider or their nearest training location
+            </span>
+          </dd>
           <dt class="govuk-list--description__label">Address</dt>
-          <dd>@courseGroup.Courses.First().ProviderLocation.Address</dd>
+          <dd>
+            @courseGroup.Courses.First().DistanceAddress.Replace("\n", ", ")
+          </dd>
         }
       </dl>
       @if(courseGroup.Courses.Count() > 1)

--- a/src/Views/Results/Display/Map.cshtml
+++ b/src/Views/Results/Display/Map.cshtml
@@ -57,6 +57,11 @@
 </ul>
 
 <script>
+  window.search_location = [{
+    "lat": @(mapModel.Map.MyLocation.Latitude),
+    "lng": @(mapModel.Map.MyLocation.Longitude)
+  }]
+
   window.locations = [
     @foreach (var courseGroup in Model.Map.CourseGroups)
     {


### PR DESCRIPTION
### Context
Users like to see their search location indicated on the map and a decent zoom level closely defined to their search area but with the ability to zoom out to see more.

### Changes proposed in this pull request
- Add map marker for user search location
- Set zoom level
- Remove `fitBounds` && `panToBounds`

### Guidance to review
# Before
<img width="1384" alt="screen shot 2018-10-10 at 21 47 15" src="https://user-images.githubusercontent.com/3071606/46765093-10b27a80-ccd6-11e8-8fe1-ca54ad4a6dad.png">

# After
<img width="1384" alt="screen shot 2018-10-10 at 21 45 41" src="https://user-images.githubusercontent.com/3071606/46765120-23c54a80-ccd6-11e8-9954-059546348b6c.png">



