### PR TITLE
Added provider code to search results

### DIFF
--- a/src/Controllers/DynamicController.cs
+++ b/src/Controllers/DynamicController.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             var res = _api.GetProviderSuggestions(query);
             return Json(res
-                .Select(x => x.Name)
+                .Select(x => x.Name + "(" + x.ProviderCode + ")")
                 .ToList());
         }
 

--- a/src/Controllers/DynamicController.cs
+++ b/src/Controllers/DynamicController.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             var res = _api.GetProviderSuggestions(query);
             return Json(res
-                .Select(x => x.Name + "(" + x.ProviderCode + ")")
+                .Select(x => x.Name + " (" + x.ProviderCode + ")")
                 .ToList());
         }
 

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -81,9 +81,13 @@
                 <div class"form-group">
                   <label class="govuk-label" for="query">
                     School, university or other training provider
-                    @if (@Model.Errors.HasError("query")) {
+                    @if (@Model.Errors.HasError("query"))
+                    {
                       <span class="govuk-error-message">@Model.Errors.GetError("query").Message</span>
                     }
+                  </label>
+                  <label class="govuk-label" for="query">
+                    (enter the name or provider code)
                   </label>
                   <input class="govuk-input typeahead" data-url="@Url.Action("ProviderSuggest", "Dynamic")" name="query" type="text" id="query" value="@Model.FilterModel.query">
                 </div>


### PR DESCRIPTION
### Context
There is a requirement to search by Ucas provider code on the Search By Location page.
https://trello.com/c/RHCRbSz8/431-search-by-provider-code-on-location-search-page

### Changes proposed in this pull request
There is now an extra step in the Api which now searches the provider code field as well as the provider name field for the user entry. The results now include the provider code for all queries.

![searchbyprovidercode1](https://user-images.githubusercontent.com/6573457/46858538-65074880-ce03-11e8-8d7b-20eeeeae039c.png)

![searchbyprovidercode2](https://user-images.githubusercontent.com/6573457/46858544-69cbfc80-ce03-11e8-9c0d-a3008baafecc.png)

![searchbyprovidercode3](https://user-images.githubusercontent.com/6573457/46858549-6df81a00-ce03-11e8-9a5a-d9b4750939be.png)


