### PR TITLE
Fix JS back link to use document.referrer instead of .back()

### DIFF
--- a/src/Assets/Javascript/__snapshots__/back-link.test.js.snap
+++ b/src/Assets/Javascript/__snapshots__/back-link.test.js.snap
@@ -5,7 +5,7 @@ Array [
   Array [
     <a
       class="govuk-back-link"
-      href="javascript:history.back()"
+      href="http://localhost"
     >
       Back to search results
     </a>,

--- a/src/Assets/Javascript/back-link.js
+++ b/src/Assets/Javascript/back-link.js
@@ -14,7 +14,7 @@ BackLink.prototype.init = function() {
 
     if ($isInternalReferrer) {
       var $link = document.createElement("a")
-      $link.setAttribute("href", "javascript:history.back()")
+      $link.setAttribute("href", document.referrer)
       $link.setAttribute("class", "govuk-back-link")
       $link.textContent = "Back to search results"
 


### PR DESCRIPTION
Not sure if there's a downside to this, but it seems to work great and removes a bug.