### PR TITLE
Financial support

### DIFF
--- a/shared/ViewFormatters/CourseExtensions.cs
+++ b/shared/ViewFormatters/CourseExtensions.cs
@@ -101,17 +101,27 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters
             return date.Value.ToString("MMMM yyyy", CultureInfo.CreateSpecificCulture("en-US"));
         }
 
+        public static bool HasScholarshipAndBursary(this Course course)
+        {
+            return course.CourseSubjects.Any(cs => cs.Subject.Funding != null && cs.Subject.Funding.Scholarship != null);
+        }
+
+        public static bool HasBursary(this Course course)
+        {
+            return course.CourseSubjects.Any(cs => cs.Subject.Funding != null);
+        }
+
         public static string FundingOptions(this Course course)
         {
             if (course.Route.IsSalaried)
             {
                 return "Salary";
             }
-            else if (course.CourseSubjects.Any(cs => cs.Subject.Funding != null && cs.Subject.Funding.Scholarship != null))
+            else if (course.HasScholarshipAndBursary())
             {
                 return "Scholarship, bursary or student finance if you’re eligible";
             }
-            else if (course.CourseSubjects.Any(cs => cs.Subject.Funding != null))
+            else if (course.HasBursary())
             {
                 return "Bursary or student finance if you’re eligible";
             }

--- a/shared/ViewModels/FinanceViewModel.cs
+++ b/shared/ViewModels/FinanceViewModel.cs
@@ -68,6 +68,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
             }
         }
 
+        public bool HasEarlyCareerPayments => Course.CourseSubjects.Any(cs => cs.Subject.Funding != null && cs.Subject.Funding.EarlyCareerPayments != null);
         public string CurrencyMaxScholarship => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxScholarship);
         public string FormattedMaxScholarship =>  $"Up to {CurrencyMaxScholarship} tax free scholarship while you train";
 

--- a/shared/ViewModels/FinanceViewModel.cs
+++ b/shared/ViewModels/FinanceViewModel.cs
@@ -12,9 +12,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
 
         public FeeCaps FeeCaps { get; set; }
 
-        public bool IsSalaried {
-            get { return Course.IsSalaried; }
-        }
+        public bool IsSalaried => Course.IsSalaried;
 
         public string FormattedEuFees {
             get { return string.Format(CultureInfo.InvariantCulture, "£{0:n0}", Course.Fees.Eu); }
@@ -70,12 +68,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
             }
         }
 
-        public string FormattedMaxScholarship {
-            get
-            {
-                return string.Format(CultureInfo.InvariantCulture, "Up to £{0:n0} tax free scholarship while you train", MaxScholarship);
-            }
-        }
+        public string CurrencyMaxScholarship => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxScholarship);
+        public string FormattedMaxScholarship =>  $"Up to {CurrencyMaxScholarship} tax free scholarship while you train";
 
         public int? MaxBursary {
             get
@@ -87,12 +81,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
             }
         }
 
-        public string FormattedMaxBursary {
-            get
-            {
-                return string.Format(CultureInfo.InvariantCulture, "Up to £{0:n0} tax free bursary while you train", MaxBursary);
-            }
-        }
+        public string CurrencyMaxBursary => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxBursary);
+
+        public string FormattedMaxBursary =>  $"Up to {CurrencyMaxBursary} tax free bursary while you train";
 
         public FinanceViewModel(Course course, FeeCaps feeCaps)
         {

--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -138,7 +138,7 @@
             @await Html.PartialAsync("_Fees.cshtml")
           }
 
-          @await Html.PartialAsync("_FinancialSupport.cshtml")
+          @await Html.PartialAsync("FinancialSupport/_FinancialSupport.cshtml")
 
           @await Html.PartialAsync("_EntryRequirementsQualifications.cshtml")
 

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
@@ -1,0 +1,25 @@
+@{
+  var bursary = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 20000);
+  var requirements = new List<string>() {"a degree of 2:2 or above in any subject", "at least grade B in maths A-level (or an equivalent)"};
+  var requirementsOneLiner = requirements.Count() == 1;
+  var firstLineEnding = requirementsOneLiner ? ":" : $" {requirements[0]}.";
+  var firstLine = $"You’ll get a bursary of {bursary} if you have{firstLineEnding}";
+}
+
+<p class="govuk-body">
+  @firstLineEnding
+</p>
+
+@if(!requirementsOneLiner)
+{
+  <ul class="list list-bullet">
+    @foreach(var requirement in requirements)
+    {
+      <li>@requirement</li>
+    }
+  </ul>
+}
+
+<p class="govuk-body">
+  You don’t have to apply for a bursary - you’ll automatically start receiving it once you begin your course. Find out <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid">how you’ll be paid</a>.
+</p>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
@@ -2,7 +2,13 @@
 
 @{
   var bursary = Model.Finance.CurrencyMaxBursary;
-  var requirements = new List<string>() {"a degree of 2:2 or above in any subject", "at least grade B in maths A-level (or an equivalent)"};
+  var requirements = new List<string>() {"a degree of 2:2 or above in any subject"};
+
+  if(Model.Course.CourseSubjects.Any(x => x.Subject != null &&  x.Subject.Name.Equals("Primary with Mathematics", StringComparison.InvariantCultureIgnoreCase)))
+  {
+    requirements.Add("at least grade B in maths A-level (or an equivalent)");
+  }
+
   var requirementsOneLiner = requirements.Count() == 1;
   var firstLineEnding = requirementsOneLiner ? $" {requirements[0]}." : ":";
   var firstLine = $"You’ll get a bursary of {bursary} if you have{firstLineEnding}";

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
@@ -4,7 +4,7 @@
   var bursary = Model.Finance.CurrencyMaxBursary;
   var requirements = new List<string>() {"a degree of 2:2 or above in any subject"};
 
-  if(Model.Course.CourseSubjects.Any(x => x.Subject != null &&  x.Subject.Name.Equals("Primary with Mathematics", StringComparison.InvariantCultureIgnoreCase)))
+  if(Model.Course.CourseSubjects.Any(x => x.Subject != null && x.Subject.Name.Equals("Primary with Mathematics", StringComparison.InvariantCultureIgnoreCase)))
   {
     requirements.Add("at least grade B in maths A-level (or an equivalent)");
   }

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Bursary.cshtml
@@ -1,24 +1,26 @@
+@model GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel;
+
 @{
-  var bursary = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 20000);
+  var bursary = Model.Finance.CurrencyMaxBursary;
   var requirements = new List<string>() {"a degree of 2:2 or above in any subject", "at least grade B in maths A-level (or an equivalent)"};
   var requirementsOneLiner = requirements.Count() == 1;
-  var firstLineEnding = requirementsOneLiner ? ":" : $" {requirements[0]}.";
+  var firstLineEnding = requirementsOneLiner ? $" {requirements[0]}." : ":";
   var firstLine = $"You’ll get a bursary of {bursary} if you have{firstLineEnding}";
 }
 
-<p class="govuk-body">
-  @firstLineEnding
-</p>
+  <p class="govuk-body">
+    @firstLine
+  </p>
 
-@if(!requirementsOneLiner)
-{
-  <ul class="list list-bullet">
-    @foreach(var requirement in requirements)
-    {
-      <li>@requirement</li>
-    }
-  </ul>
-}
+  @if(!requirementsOneLiner)
+  {
+    <ul class="govuk-list govuk-list--bullet">
+      @foreach(var requirement in requirements)
+      {
+        <li>@requirement</li>
+      }
+    </ul>
+  }
 
 <p class="govuk-body">
   You don’t have to apply for a bursary - you’ll automatically start receiving it once you begin your course. Find out <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid">how you’ll be paid</a>.

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Default.cshtml
@@ -1,0 +1,7 @@
+
+<p class="govuk-body">
+  You may be eligible for a <a href="https://www.gov.uk/teacher-training-funding" class="govuk-link">loan while you study</a>.
+</p>
+<p class="govuk-body">
+  <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside of the UK</a>.
+</p>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Default.cshtml
@@ -1,7 +1,0 @@
-
-<p class="govuk-body">
-  You may be eligible for a <a href="https://www.gov.uk/teacher-training-funding" class="govuk-link">loan while you study</a>.
-</p>
-<p class="govuk-body">
-  <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside of the UK</a>.
-</p>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
@@ -7,23 +7,15 @@
 
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
+
   @if (Model.Course.IsSalaried)
   {
-    <p class="govuk-body">
-      Financial support isn’t available for this course because it comes with a salary.
-    </p>
-    <p class="govuk-body">
-      If you choose a course without a salary, you may be eligible for financial support while you study, including bursaries, scholarships and loans.
-    </p>
+    @await Html.PartialAsync("_Salaried.cshtml");
   }
   else
   {
-    <p class="govuk-body">
-      You may be eligible for <a href="https://www.gov.uk/teacher-training-funding" class="govuk-link">financial support while you study, including bursaries, scholarships and loans</a>.
-    </p>
-    <p class="govuk-body">
-      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside of the UK</a>.
-    </p>
+    @if(Model.)
+    @await Html.PartialAsync("_Default.cshtml");
   }
 
   @if(Model.HasSection(CourseDetailsSections.FinancialSupport))

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
@@ -4,17 +4,26 @@
 @using GovUk.Education.SearchAndCompare.Domain.Models.Enums;
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters;
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
-
+@{
+  var course = Model.Course;
+}
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
 
-  @if (Model.Course.IsSalaried)
+  @if (course.IsSalaried)
   {
     @await Html.PartialAsync("_Salaried.cshtml");
   }
+  else if (course.HasScholarshipAndBursary())
+  {
+    @await Html.PartialAsync("_ScholarshipAndBursary.cshtml");
+  }
+  else if (course.HasBursary())
+  {
+    @await Html.PartialAsync("_Bursary.cshtml");
+  }
   else
   {
-    @if(Model.)
     @await Html.PartialAsync("_Default.cshtml");
   }
 

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
@@ -32,7 +32,7 @@
     }
 
     <p class="govuk-body">
-      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside of the UK</a>.
+      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside the UK</a>.
     </p>
   }
 

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_FinancialSupport.cshtml
@@ -7,6 +7,7 @@
 @{
   var course = Model.Course;
 }
+
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
 
@@ -14,17 +15,25 @@
   {
     @await Html.PartialAsync("_Salaried.cshtml");
   }
-  else if (course.HasScholarshipAndBursary())
-  {
-    @await Html.PartialAsync("_ScholarshipAndBursary.cshtml");
-  }
-  else if (course.HasBursary())
-  {
-    @await Html.PartialAsync("_Bursary.cshtml");
-  }
-  else
-  {
-    @await Html.PartialAsync("_Default.cshtml");
+  else {
+    if (course.HasScholarshipAndBursary())
+    {
+      @await Html.PartialAsync("_ScholarshipAndBursary.cshtml");
+    }
+    else if (course.HasBursary())
+    {
+      @await Html.PartialAsync("_Bursary.cshtml");
+    }
+    else
+    {
+      <p class="govuk-body">
+        You may be eligible for a <a href="https://www.gov.uk/teacher-training-funding" class="govuk-link">loan while you study</a>.
+      </p>
+    }
+
+    <p class="govuk-body">
+      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside of the UK</a>.
+    </p>
   }
 
   @if(Model.HasSection(CourseDetailsSections.FinancialSupport))

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Salaried.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_Salaried.cshtml
@@ -1,0 +1,7 @@
+
+<p class="govuk-body">
+  Financial support isn’t available for this course because it comes with a salary.
+</p>
+<p class="govuk-body">
+  If you choose a course without a salary, you may be eligible for financial support while you study, including bursaries, scholarships and loans.
+</p>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
@@ -4,8 +4,11 @@
   var scholarship = Model.Finance.CurrencyMaxScholarship;
   var bursary = Model.Finance.CurrencyMaxBursary;
 
-  var isMaths = Model.Course.Name.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase);
-  var subjectName = isMaths ? "maths" : Model.Course.Name;
+
+  var courseSubjectName = Model.Course.CourseSubjects.FirstOrDefault(x => x.Subject != null)?.Subject?.Name;
+
+  var isMaths = courseSubjectName.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase);
+  var subjectName = isMaths ? "maths" : courseSubjectName;
 }
 
 <p class="govuk-body">

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
@@ -3,7 +3,9 @@
 @{
   var scholarship = Model.Finance.CurrencyMaxScholarship;
   var bursary = Model.Finance.CurrencyMaxBursary;
-  var subjectName = Model.Course.Name;
+
+  var isMaths = Model.Course.Name.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase);
+  var subjectName = isMaths ? "maths" : Model.Course.Name;
 }
 
 <p class="govuk-body">
@@ -15,9 +17,12 @@
   <li>a bursary of @bursary</li>
 </ul>
 
-<p class="govuk-body">
-  With a scholarship or bursary, you’ll also get early career payments of £5,000 each in your third and fifth year of teaching (£7,500 in <a href="https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools">some areas of England</a>).
-</p>
+@if(Model.Finance.HasEarlyCareerPayments)
+{
+  <p class="govuk-body">
+    With a scholarship or bursary, you’ll also get early career payments of £5,000 each in your third and fifth year of teaching (£7,500 in <a href="https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools">some areas of England</a>).
+  </p>
+}
 
 <p class="govuk-body">
   To qualify for a scholarship you’ll need a degree of 2:1 or above in @subjectName or a related subject. For a bursary you’ll need a 2:2 or above in any subject.

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
@@ -1,8 +1,8 @@
 @model GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel;
 
 @{
-  var scholarship = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 22000);
-  var bursary = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 20000);
+  var scholarship = Model.Finance.CurrencyMaxScholarship;
+  var bursary = Model.Finance.CurrencyMaxBursary;
   var subjectName = Model.Course.Name;
 }
 
@@ -10,7 +10,7 @@
   You could be eligible for either:
 </p>
 
-<ul class="list list-bullet">
+<ul class="govuk-list govuk-list--bullet">
   <li>a scholarship of @scholarship</li>
   <li>a bursary of @bursary</li>
 </ul>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
@@ -1,0 +1,30 @@
+@{
+  var scholarship = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 22000);
+  var bursary = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 20000);
+  var subjectName = "subjectName";
+}
+
+<p class="govuk-body">
+  You could be eligible for either:
+</p>
+
+<ul class="list list-bullet">
+  <li>a scholarship of @scholarship</li>
+  <li>a bursary of @bursary</li>
+</ul>
+
+<p class="govuk-body">
+  With a scholarship or bursary, you’ll also get early career payments of £5,000 each in your third and fifth year of teaching (£7,500 in <a href="https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools">some areas of England</a>).
+</p>
+
+<p class="govuk-body">
+  To qualify for a scholarship you’ll need a degree of 2:1 or above in @subjectName or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
+</p>
+
+<p class="govuk-body">
+  You can’t claim both a bursary and a scholarship - you can only claim one.
+</p>
+
+<p class="govuk-body">
+  Find out how to <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/scholarships">apply for a scholarship</a>. You don’t need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <a href="https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid">how you’ll be paid</a>.
+</p>

--- a/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/FinancialSupport/_ScholarshipAndBursary.cshtml
@@ -1,7 +1,9 @@
+@model GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel;
+
 @{
   var scholarship = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 22000);
   var bursary = String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", 20000);
-  var subjectName = "subjectName";
+  var subjectName = Model.Course.Name;
 }
 
 <p class="govuk-body">


### PR DESCRIPTION
### Context

The copy text should denote:

For MATHS SECONDARY subject
- scholarship 
- bursary 
- early career payments 
- additional requirements

For PRIMARY MATHS subject
- bursary 
- additional requirements


For subjects that has both
- scholarship 
- bursary 


For subjects that only has
- bursary 

### Changes proposed in this pull request
The copy text for the denoted the subjects and the financial support offered for 
- scholarship 
- bursary 
- early career payments (just maths)
- additional requirements (just maths)


are tailored.

And the default blank financial support are amended.

### Guidance to review
Some items are hard coded as it will not change for an entire year as discussed with @benilovj 

default
![image](https://user-images.githubusercontent.com/470137/46949735-55de0000-d07a-11e8-907f-0dbd025f439b.png)

MATHS SECONDARY
![image](https://user-images.githubusercontent.com/470137/46949784-7d34cd00-d07a-11e8-993b-ea21493e404b.png)

PRIMARY MATHS
![image](https://user-images.githubusercontent.com/470137/46949821-9d648c00-d07a-11e8-8bec-43691d5c3398.png)


- scholarship 
- bursary 
refer to _ScholarshipAndBursary.cshtml
![image](https://user-images.githubusercontent.com/470137/46951340-9724de80-d07f-11e8-8695-c4cd98b0ffad.png)

- bursary 
refer to _Bursary.cshtml
![image](https://user-images.githubusercontent.com/470137/46949867-c258ff00-d07a-11e8-98e5-2fbd61809447.png)

