### PR TITLE
Cope with blank feature flags

### DIFF
--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         public bool Apply2019 => ShouldShow("FEATURE_APPLY_2019");
         public bool Maps => ShouldShow("FEATURE_MAPS");
 
-        private bool ShouldShow(string key)
+        public bool ShouldShow(string key)
         {
             var value = _config[key];
             return !string.IsNullOrWhiteSpace(value) && value.Trim().ToLower().Equals("true");

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -17,6 +17,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         public bool Apply2019 => ShouldShow("FEATURE_APPLY_2019");
         public bool Maps => ShouldShow("FEATURE_MAPS");
 
-        private bool ShouldShow(string key) => _config.GetValue(key, false);
+        private bool ShouldShow(string key)
+        {
+            var value = _config[key];
+            return !string.IsNullOrWhiteSpace(value) && value.Trim().ToLower().Equals("true");
+        }
     }
 }

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using GovUk.Education.SearchAndCompare.UI.Shared.Features;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests
+{
+    [TestFixture]
+    public class FeatureFlagsTests
+    {
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        [Test]
+        public void FeatureFlagConfigTests(string configValue, bool expected)
+        {
+            var config = new Mock<IConfiguration>();
+            const string key = "FEATURE_THING";
+            config.Setup(c => c[key]).Returns(configValue);
+            var featureFlags = new FeatureFlags(config.Object);
+            featureFlags.ShouldShow(key).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
### Context
Prod died because of an empty string in a feature flag.

### Changes proposed in this pull request
Anything except `trim('true')` (case insensitive) is now false
