### PR TITLE
Removed-provider-code-from-results

### DIFF
--- a/src/Controllers/DynamicController.cs
+++ b/src/Controllers/DynamicController.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             var res = _api.GetProviderSuggestions(query);
             return Json(res
-                .Select(x => x.Name + " (" + x.ProviderCode + ")")
+                .Select(x => x.Name)
                 .ToList());
         }
 


### PR DESCRIPTION
### Context
The search by provider code is causing an issue with the location search as the provider code is brought into the search string. We are working on a fix for this but in the meantime we need to revert the ui change to fix dev. 