### PR TITLE
Disable source maps for JS in production mode

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -5,7 +5,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const CopyWebpackPlugin = require("copy-webpack-plugin")
 
 module.exports = {
-  devtool: "inline-source-map",
+  devtool: process.env.NODE_ENV === "development" ? "inline-source-map" : "",
   entry: {
     application: "./Assets/app.js"
   },


### PR DESCRIPTION
### Context

These add significant needless weight to the production bundle.

### Savings

This reduces the bundle size from **1.03MB** to **151.39KB**, a saving of **86%**. [1]

[1] These measurements are taken in Safari and seem to not include gzipping AFAICT.