### PR TITLE
Display provider codes in autocomplete

### DIFF
--- a/src/Assets/Javascript/autocomplete.js
+++ b/src/Assets/Javascript/autocomplete.js
@@ -25,6 +25,10 @@ export const requestFromApi = endpoint => {
   }
 }
 
+const inputValueTemplate = result => (typeof result === "string" ? result : result && result.name)
+const suggestionTemplate = result =>
+  typeof result === "string" ? result : result && `${result.name} (${result.providerCode})`
+
 const initAutocomplete = ($el, $input) => {
   accessibleAutocomplete({
     element: $el,
@@ -33,7 +37,11 @@ const initAutocomplete = ($el, $input) => {
     name: $input.getAttribute("name"),
     defaultValue: $input.value,
     minLength: 3,
-    source: requestFromApi($input.getAttribute("data-url"))
+    source: requestFromApi($input.getAttribute("data-url")),
+    templates: {
+      inputValue: inputValueTemplate,
+      suggestion: suggestionTemplate
+    }
   })
 
   $input.parentNode.removeChild($input)

--- a/src/Controllers/DynamicController.cs
+++ b/src/Controllers/DynamicController.cs
@@ -29,9 +29,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public JsonResult ProviderSuggest(string query)
         {
             var res = _api.GetProviderSuggestions(query);
-            return Json(res
-                .Select(x => x.Name)
-                .ToList());
+            return Json(res.Select(x => new { name = x.Name, providerCode = x.ProviderCode }).ToList());
         }
 
         [HttpGet("/dynamic/locationsuggest")]
@@ -43,7 +41,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             {
                 res = await _geocoder.SuggestLocationsAsync(query);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _telemetryClient.TrackException(ex);
             }


### PR DESCRIPTION
### Context

On a number of provider websites, they advise candidates to search by their UCAS provider code.

### Changes proposed

Sends JSON objects from the API endpoint and handles them on the frontend in the autocomplete. 

### Guidance to review

Depends on #242. Only the last 2 commits in this are relevant.