### PR TITLE
Show campus locations on map instead of provider locations

### DIFF
--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -37,6 +37,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             return courses.Items
                 .SelectMany(c => c.Campuses)
+                .Where(c => c.Location != null)
                 .GroupBy(
                     campus => campus.Location.AsCoordinates(),
                     campus => campus.Course,

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -10,7 +10,6 @@ using GovUk.Education.SearchAndCompare.UI.Services.Maps;
 using GovUk.Education.SearchAndCompare.UI.Services.Maps.Models;
 using GovUk.Education.SearchAndCompare.UI.Shared.Features;
 using GovUk.Education.SearchAndCompare.UI.ViewModels;
-using GovUk.Education.SearchAndCompare.ViewFormatters;
 using GovUk.Education.SearchAndCompare.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -31,22 +30,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult Map(ResultsFilter filter)
         {
             return RedirectToAction("Index", "Results", filter.ToRouteValues());
-        }
-
-        private static List<CourseGroup> GroupCoursesByCampusLocation(PaginatedList<Course> courses)
-        {
-            return courses.Items
-                .SelectMany(c => c.Campuses)
-                .Where(c => c.Location?.Latitude != null && c.Location?.Longitude != null)
-                .GroupBy(
-                    campus => campus.Location.AsCoordinates(),
-                    campus => campus.Course,
-                    (key, groupedCourses) => new CourseGroup
-                    {
-                        Coordinates = key,
-                        Courses = groupedCourses.ToList(),
-                    }
-                ).ToList();
         }
 
         [HttpGet("results")]
@@ -124,7 +107,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
 
             queryFilter.pageSize = 0;
             courses = _api.GetCourses(queryFilter);
-            var courseGroups = GroupCoursesByCampusLocation(courses);
+            var courseGroups = courses.Items.GroupCoursesByCampusLocation().ToList();
             if (!courseGroups.Any())
             {
                 throw new Exception("No locations found");
@@ -148,6 +131,5 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             return RedirectToAction("Index", "Results", filter.ToRouteValues());
         }
-
     }
 }

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         {
             return courses.Items
                 .SelectMany(c => c.Campuses)
-                .Where(c => c.Location != null)
+                .Where(c => c.Location?.Latitude != null && c.Location?.Longitude != null)
                 .GroupBy(
                     campus => campus.Location.AsCoordinates(),
                     campus => campus.Course,
@@ -125,6 +125,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             queryFilter.pageSize = 0;
             courses = _api.GetCourses(queryFilter);
             var courseGroups = GroupCoursesByCampusLocation(courses);
+            if (!courseGroups.Any())
+            {
+                throw new Exception("No locations found");
+            }
 
             IMapProjection<CourseGroup> mapProjection = new MapProjection<CourseGroup>(courseGroups, filter.Coordinates, 400, filter.zoomlevel);
 

--- a/src/ExtensionsMethods/CourseExtensionMethods.cs
+++ b/src/ExtensionsMethods/CourseExtensionMethods.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.SearchAndCompare.UI.Services.Maps.Models;
+using GovUk.Education.SearchAndCompare.ViewFormatters;
+
+namespace GovUk.Education.SearchAndCompare.Domain.Models
+{
+    public static class CourseExtensionMethods
+    {
+        public static IEnumerable<CourseGroup> GroupCoursesByCampusLocation(this IEnumerable<Course> courses)
+        {
+            return courses
+                .SelectMany(c => c.Campuses)
+                .Where(c => c.Location?.Latitude != null && c.Location?.Longitude != null)
+                .GroupBy(
+                    campus => campus.Location.AsCoordinates(),
+                    campus => campus.Course,
+                    (key, groupedCourses) => new CourseGroup
+                    {
+                        Coordinates = key,
+                        Courses = groupedCourses.ToList(),
+                    }
+                );
+        }
+    }
+}

--- a/src/Services/Maps/MapProjection.cs
+++ b/src/Services/Maps/MapProjection.cs
@@ -6,7 +6,7 @@ using GovUk.Education.SearchAndCompare.UI.Services.Maps.Models;
 
 namespace GovUk.Education.SearchAndCompare.UI.Services.Maps
 {
-    public class MapProjection<T> : IMapProjection<T> where T: IMapMarker
+    public class MapProjection<T> : IMapProjection<T> where T : IMapMarker
     {
         private int _pinRadius = 9;
 
@@ -70,14 +70,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Services.Maps
             get { return (Math.Min(ZoomLevel + 1, _maxZoomLevel)); }
         }
 
-        public MapProjection(IEnumerable<T> markers, Coordinates myLocation, int? height, int? zoomLevel)
+        public MapProjection(IList<T> markers, Coordinates myLocation, int? height, int? zoomLevel)
         {
             _markers = markers;
             MyLocation = myLocation;
             Centre = CalculateMapCentre(markers);
             Width = _defaultWidth;
             Height = height ?? _defaultHeight;
-            ZoomLevel = zoomLevel?? FitZoomLevel(markers);
+            ZoomLevel = zoomLevel ?? FitZoomLevel(markers);
         }
 
         public IEnumerable<T> MarkersWithAreas
@@ -97,7 +97,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services.Maps
 
         private void AddMapMarker(IMapMarker marker, char? label)
         {
-            marker.Area = AreaFromCoordinates(marker.Coordinates, string.Format("{0}", label?? '.'));
+            marker.Area = AreaFromCoordinates(marker.Coordinates, string.Format("{0}", label ?? '.'));
         }
 
         private IHtmlArea AreaFromCoordinates(Coordinates coordinates, string name)
@@ -137,7 +137,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services.Maps
                 && pixelCoordinates.Y > (_pinRadius * 2 + _pinOffset);
         }
 
-        private int FitZoomLevel(IEnumerable<T> markers)
+        private int FitZoomLevel(IList<T> markers)
         {
             // Find max and min coords in pixel space at a given zoom level
             // Determine if these fall within +/- size of map in pixels
@@ -181,8 +181,12 @@ namespace GovUk.Education.SearchAndCompare.UI.Services.Maps
             }
         }
 
-        private Coordinates CalculateMapCentre(IEnumerable<T> markerCoordinates)
+        private Coordinates CalculateMapCentre(IList<T> markerCoordinates)
         {
+            if (markerCoordinates == null || !markerCoordinates.Any())
+            {
+                throw new ArgumentException("Can't calculate map centre when there aren't any markers", nameof(markerCoordinates));
+            }
             // Halfway between minimum and maximum
             var minLatitude = markerCoordinates.Min(x => x.Coordinates.Latitude);
             var maxLatitude = markerCoordinates.Max(x => x.Coordinates.Latitude);

--- a/tests/Unit.Tests/Controllers/ResultsControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/ResultsControllerTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Filters;
+using GovUk.Education.SearchAndCompare.Domain.Lists;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI.Controllers;
+using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Shared.Features;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
+{
+    [TestFixture]
+    public class ResultsControllerTests
+    {
+        [Test]
+        public void ReturnsNameAndLocation()
+        {
+            // arrange
+            var apiMock = new Mock<ISearchAndCompareApi>();
+            apiMock.Setup(a => a.GetSubjects()).Returns(new List<Subject>());
+            const double latitude = 12.34;
+            const double longitude = 56.78;
+            const string courseName = "defence against the dark arts";
+            var campus = new Campus
+            {
+                Location = new Location
+                {
+                    Latitude = latitude,
+                    Longitude = longitude,
+                },
+            };
+            var course = new Course
+            {
+                Name = courseName,
+                Campuses = new List<Campus>
+                {
+                    campus,
+                },
+            };
+            campus.Course = course;
+            var paginatedList = new PaginatedList<Course>
+            {
+                Items = new List<Course>
+                {
+                    course,
+                },
+            };
+            apiMock.Setup(a => a.GetCourses(It.IsAny<QueryFilter>())).Returns(paginatedList);
+            var flagsMock = new Mock<IFeatureFlags>();
+            var resultsController = new ResultsController(apiMock.Object, flagsMock.Object);
+            var filter = new ResultsFilter();
+
+            // act
+            var actionResult = resultsController.ResultsMap(filter);
+
+            // assert
+            actionResult.Should().BeOfType<ViewResult>();
+            var viewResult = (ViewResult)actionResult;
+            var model = viewResult.Model;
+            model.Should().BeOfType<ResultsViewModel>();
+            var resultsModel = (ResultsViewModel)model;
+            resultsModel.Should().NotBeNull();
+            resultsModel.Map.Should().NotBeNull();
+            resultsModel.Map.CourseGroups.Should().NotBeNull();
+            var courseGroups = resultsModel.Map.CourseGroups.ToList();
+            courseGroups.Should().HaveCount(1);
+            var courseGroup = courseGroups.Single();
+            courseGroup.Coordinates.Should().NotBeNull();
+            courseGroup.Coordinates.Latitude.Should().Be(latitude);
+            courseGroup.Coordinates.Longitude.Should().Be(longitude);
+            courseGroup.Courses.Should().NotBeNull();
+            courseGroup.Courses.Should().HaveCount(1);
+            var returnedCourse = courseGroup.Courses.Single();
+            returnedCourse.Should().NotBeNull();
+            returnedCourse.Name.Should().Be(courseName);
+        }
+    }
+}

--- a/tests/Unit.Tests/ExtensionMethods/CourseExtensionTests.cs
+++ b/tests/Unit.Tests/ExtensionMethods/CourseExtensionTests.cs
@@ -1,0 +1,91 @@
+﻿
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.ExtensionMethods
+{
+    [TestFixture]
+    public class CourseExtensionTests
+    {
+        [Test]
+        public void GroupsColocatedCourses()
+        {
+            // arrange
+            const double latitude = 12.34;
+            const double longitude = 56.78;
+            var course1 = BuildCourse(latitude, longitude, "defence against the dark arts");
+            var course2 = BuildCourse(latitude, longitude, "potions and poisons");
+            var courses = new List<Course>
+            {
+                course1,
+                course2,
+            };
+
+            // act
+            var courseGroups = courses.GroupCoursesByCampusLocation().ToList();
+
+            // assert
+            courseGroups.Should().NotBeNull();
+            courseGroups.Should().HaveCount(1);
+            var courseGroup = courseGroups.Single();
+            courseGroup.Coordinates.Should().NotBeNull();
+            courseGroup.Coordinates.Latitude.Should().Be(latitude);
+            courseGroup.Coordinates.Longitude.Should().Be(longitude);
+            courseGroup.Courses.Should().NotBeNull();
+            courseGroup.Courses.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void DoesntGroupDistantCourses()
+        {
+            // arrange
+            var course1 = BuildCourse(12.34, 56.78, "defence against the dark arts");
+            var course2 = BuildCourse(-12.34, -56.78, "potions and poisons");
+            var courses = new List<Course>
+            {
+                course1,
+                course2,
+            };
+
+            // act
+            var courseGroups = courses.GroupCoursesByCampusLocation().ToList();
+
+            // assert
+            courseGroups.Should().NotBeNull();
+            courseGroups.Should().HaveCount(2);
+            foreach (var courseGroup in courseGroups)
+            {
+                courseGroup.Coordinates.Should().NotBeNull();
+                courseGroup.Coordinates.Latitude.Should().NotBe(default(double));
+                courseGroup.Coordinates.Longitude.Should().NotBe(default(double));
+                courseGroup.Courses.Should().NotBeNull();
+                courseGroup.Courses.Should().HaveCount(1);
+            }
+        }
+
+        private static Course BuildCourse(double latitude, double longitude, string courseName)
+        {
+            var campus = new Campus
+            {
+                Location = new Location
+                {
+                    Latitude = latitude,
+                    Longitude = longitude,
+                },
+            };
+            var course = new Course
+            {
+                Name = courseName,
+                Campuses = new List<Campus>
+                {
+                    campus,
+                },
+            };
+            campus.Course = course;
+            return course;
+        }
+    }
+}

--- a/tests/Unit.Tests/ExtensionMethods/CourseExtensionTests.cs
+++ b/tests/Unit.Tests/ExtensionMethods/CourseExtensionTests.cs
@@ -11,7 +11,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.ExtensionMethods
     public class CourseExtensionTests
     {
         [Test]
-        public void GroupsColocatedCourses()
+        public void ColocatedCoursesAreInSameGroup()
         {
             // arrange
             const double latitude = 12.34;
@@ -29,21 +29,21 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.ExtensionMethods
 
             // assert
             courseGroups.Should().NotBeNull();
-            courseGroups.Should().HaveCount(1);
+            courseGroups.Should().HaveCount(1, "they have the same location so should both end up in the same group");
             var courseGroup = courseGroups.Single();
             courseGroup.Coordinates.Should().NotBeNull();
             courseGroup.Coordinates.Latitude.Should().Be(latitude);
             courseGroup.Coordinates.Longitude.Should().Be(longitude);
             courseGroup.Courses.Should().NotBeNull();
-            courseGroup.Courses.Should().HaveCount(2);
+            courseGroup.Courses.Should().HaveCount(2, "the group for this location should contain both the supplied courses");
         }
 
         [Test]
-        public void DoesntGroupDistantCourses()
+        public void DistantCoursesAreInDifferentGroups()
         {
             // arrange
             var course1 = BuildCourse(12.34, 56.78, "defence against the dark arts");
-            var course2 = BuildCourse(-12.34, -56.78, "potions and poisons");
+            var course2 = BuildCourse(-82.34, -26.78, "potions and poisons");
             var courses = new List<Course>
             {
                 course1,
@@ -55,14 +55,14 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.ExtensionMethods
 
             // assert
             courseGroups.Should().NotBeNull();
-            courseGroups.Should().HaveCount(2);
+            courseGroups.Should().HaveCount(2, "locations were different so they get a group each");
             foreach (var courseGroup in courseGroups)
             {
                 courseGroup.Coordinates.Should().NotBeNull();
                 courseGroup.Coordinates.Latitude.Should().NotBe(default(double));
                 courseGroup.Coordinates.Longitude.Should().NotBe(default(double));
                 courseGroup.Courses.Should().NotBeNull();
-                courseGroup.Courses.Should().HaveCount(1);
+                courseGroup.Courses.Should().HaveCount(1, "this is the only course supplied with this location");
             }
         }
 


### PR DESCRIPTION
https://trello.com/c/QkIb2KOT/481-update-map-to-use-training-location-and-not-provider-location#

https://bat-dev-search-and-compare-ui-app.azurewebsites.net/resultsmap?lat=50.8197675&lng=-1.0879769&rad=20&loc=Portsmouth,%20UK&lq=Portsmouth,%20UK&l=1&subjects=31&sortby=2&display=map&qualification=QtsOnly&qualification=PgdePgceWithQts&qualification=Other&fulltime=False&parttime=False

## Before

![7 vm_354](https://user-images.githubusercontent.com/19378/47423988-6ed36900-d77e-11e8-99ce-b1ab39dade92.png)


## After

![7 vm_355](https://user-images.githubusercontent.com/19378/47423993-7266f000-d77e-11e8-85b4-0a56fc46e672.png)

