### PR TITLE
Bring url config into line with manage ui pattern, use new key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Runs from vscode and Visual Studio 2017 with F5.
 
 Defaults to published development API backend to make it easier to get started, override this with an environment variable to work against a local copy of the API or to alter for production environments. E.g.:
 
-Note: The `API_URI` value musn't have a trailing slash.
+Note: The `API_URL` value musn't have a trailing slash.
 
-    cd src && set API_URI=http://localhost:5001/api && dotnet run
+    cd src && set API_URL=http://localhost:5001/api && dotnet run
 
 ### Set maps config
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ Run
 
     npm install
 
+Runs from vscode and Visual Studio 2017 with F5.
+
 Runs from command line with `cd src && dotnet run`
 
-Runs from vscode and Visual Studio 2017 with F5.
+    cd src
+    dotnet run
 
 Defaults to published development API backend to make it easier to get started, override this with an environment variable to work against a local copy of the API or to alter for production environments. E.g.:
 
-Note: The `API_URL` value musn't have a trailing slash.
-
-    cd src && set API_URL=http://localhost:5001/api && dotnet run
+    cd src
+    set API_URL=http://localhost:5001 && dotnet run
 
 ### Set maps config
 

--- a/src/SearchUiConfig.cs
+++ b/src/SearchUiConfig.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.SearchAndCompare.UI
 {
     public class SearchUiConfig
     {
+        private const string ConfigKeyApiUrl = "API_URL";
+
         private readonly IConfiguration _configuration;
 
         public SearchUiConfig(IConfiguration configuration)
@@ -18,7 +21,11 @@ namespace GovUk.Education.SearchAndCompare.UI
         {
             get
             {
-                var apiUrl = _configuration["API_URL"];
+                var apiUrl = _configuration[ConfigKeyApiUrl];
+                if (string.IsNullOrWhiteSpace(apiUrl))
+                {
+                    return apiUrl;
+                }
                 // remove trailing slash
                 if (apiUrl.EndsWith("/"))
                 {
@@ -26,6 +33,14 @@ namespace GovUk.Education.SearchAndCompare.UI
                 }
                 apiUrl = apiUrl + "/api";
                 return apiUrl;
+            }
+        }
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(ApiUrl))
+            {
+                throw new Exception($"Config value {ConfigKeyApiUrl} missing");
             }
         }
     }

--- a/src/SearchUiConfig.cs
+++ b/src/SearchUiConfig.cs
@@ -24,11 +24,7 @@ namespace GovUk.Education.SearchAndCompare.UI
                 {
                     apiUrl = apiUrl.Substring(0, apiUrl.Length - 1);
                 }
-
-                if (!apiUrl.EndsWith("/api"))
-                {
-                    apiUrl = apiUrl + "/api";
-                }
+                apiUrl = apiUrl + "/api";
                 return apiUrl;
             }
         }

--- a/src/SearchUiConfig.cs
+++ b/src/SearchUiConfig.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.SearchAndCompare.UI
+{
+    public class SearchUiConfig
+    {
+        private readonly IConfiguration _configuration;
+
+        public SearchUiConfig(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public string ApiUrl => _configuration["API_URL"];
+    }
+}

--- a/src/SearchUiConfig.cs
+++ b/src/SearchUiConfig.cs
@@ -11,6 +11,26 @@ namespace GovUk.Education.SearchAndCompare.UI
             _configuration = configuration;
         }
 
-        public string ApiUrl => _configuration["API_URL"];
+        /// <summary>
+        /// Gets api url, trimming trailing slash and adding /api suffix if missing
+        /// </summary>
+        public string ApiUrl
+        {
+            get
+            {
+                var apiUrl = _configuration["API_URL"];
+                // remove trailing slash
+                if (apiUrl.EndsWith("/"))
+                {
+                    apiUrl = apiUrl.Substring(0, apiUrl.Length - 1);
+                }
+
+                if (!apiUrl.EndsWith("/api"))
+                {
+                    apiUrl = apiUrl + "/api";
+                }
+                return apiUrl;
+            }
+        }
     }
 }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -89,6 +89,7 @@ namespace GovUk.Education.SearchAndCompare.UI
             app.AddContentLanguageHeaders("en");
 
             var config = serviceProvider.GetService<SearchUiConfig>();
+            config.Validate();
             _logger.LogInformation($"Using API base URL: {config.ApiUrl}");
 
             app.UseMvc(routes =>

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -7,7 +7,5 @@
       "Microsoft": "Information"
     }
   },
-  "ApiConnection": {
-    "Uri": "https://bat-dev-search-and-compare-api-app.azurewebsites.net/api/"
-  }
+  "API_URL": "https://bat-dev-search-and-compare-api-app.azurewebsites.net/api"
 }

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -7,5 +7,5 @@
       "Microsoft": "Information"
     }
   },
-  "API_URL": "https://bat-dev-search-and-compare-api-app.azurewebsites.net/api"
+  "API_URL": "https://bat-dev-search-and-compare-api-app.azurewebsites.net"
 }


### PR DESCRIPTION
### Context

Endless confusion caused by subtle differences between the way config works in manage vs search.

### Changes proposed in this pull request

* Introduce matching config that matches pattern in manage-ui https://github.com/DFE-Digital/manage-courses-ui/blob/master/src/ui/ManageCoursesConfig.cs
* Change api_url config key to a new standard name, to also be done in manage-ui. There's already a terrrrraform pr out.


