### PR TITLE
Throw when null subject list returned from api call

### DIFF
--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -67,6 +67,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult Index(ResultsFilter filter)
         {
             var subjects = api.GetSubjects();
+            if (subjects == null)
+            {
+                throw new Exception("Failed to retrieve subject list from api");
+            }
             filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption>{QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other};
 
             FilteredList<Subject> filteredSubjects;


### PR DESCRIPTION
Got this with a misconfigured api url during local dev.
Better than the original null ref exception.
