### PR TITLE
Update heroku config to expect API_URL env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "scripts": {
   },
   "env": {
-    "API_URI": {
+    "API_URL": {
       "required": true
     },
     "FEATURE_MAPS": {


### PR DESCRIPTION
This fixes the review apps.

This was changed in https://github.com/DFE-Digital/search-and-compare-ui/pull/249.

I've also updated the config vars on the actual app:

```
heroku config --app search-and-compare-ui
heroku config:set API_URL="foo" --app search-and-compare-ui
heroku config:remove API_URI --app search-and-compare-ui
```