### PR TITLE
Pass in HttpClient with a set HandlerLifetime into SCAPI

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -49,10 +49,14 @@ namespace GovUk.Education.SearchAndCompare.UI
 
             services.AddSingleton<SearchUiConfig, SearchUiConfig>();
 
+            services.AddHttpClient<IHttpClient, HttpClientWrapper>(x => x.Timeout = TimeSpan.FromSeconds(15))
+                 .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
             services.AddSingleton<ISearchAndCompareApi>(serviceProvider =>
             {
                 var config = serviceProvider.GetService<SearchUiConfig>();
-                return new SearchAndCompareApi(new HttpClient(), config.ApiUrl);
+                var wrapper = serviceProvider.GetService<IHttpClient>();
+                return new SearchAndCompareApi(wrapper, config.ApiUrl);
             });
 
             services.AddScoped<IFeatureFlags, FeatureFlags>();
@@ -99,7 +103,7 @@ namespace GovUk.Education.SearchAndCompare.UI
                 routes.MapRoute("tandc", "terms-conditions",
                     defaults: new { controller = "Legal", action = "TandC" });
                 routes.MapRoute("sitemap", "sitemap.txt",
-                    defaults: new { controller = "Sitemap", action = "Index"});
+                    defaults: new { controller = "Sitemap", action = "Index" });
             });
         }
     }


### PR DESCRIPTION
### Context

Hardening the HttpClient handler with more eager timeouts.

### Changes proposed in this pull request

Explicitly set the HandlerLifetime to 5 minutes which means that the same instance of an HttpClient can't live for more than 5 minutes.

We're also setting a timeout of 15 seconds on every request. (down from the default of 100)

Paired on this with @defong.