### PR TITLE
Add retry policy to HttpClient for SCAPI

### DIFF
--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.0" />
 </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\shared\SearchAndCompareUi.Shared.csproj" />

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -49,10 +49,15 @@ namespace GovUk.Education.SearchAndCompare.UI
 
             services.AddSingleton<SearchUiConfig, SearchUiConfig>();
 
+            var REQUEST_TIMEOUT = 15;
+            services.AddHttpClient<IHttpClient, HttpClientWrapper>(x => x.Timeout = TimeSpan.FromSeconds(REQUEST_TIMEOUT))
+                 .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
             services.AddSingleton<ISearchAndCompareApi>(serviceProvider =>
             {
                 var config = serviceProvider.GetService<SearchUiConfig>();
-                return new SearchAndCompareApi(new HttpClient(), config.ApiUrl);
+                var wrapper = serviceProvider.GetService<IHttpClient>();
+                return new SearchAndCompareApi(wrapper, config.ApiUrl);
             });
 
             services.AddScoped<IFeatureFlags, FeatureFlags>();
@@ -99,7 +104,7 @@ namespace GovUk.Education.SearchAndCompare.UI
                 routes.MapRoute("tandc", "terms-conditions",
                     defaults: new { controller = "Legal", action = "TandC" });
                 routes.MapRoute("sitemap", "sitemap.txt",
-                    defaults: new { controller = "Sitemap", action = "Index"});
+                    defaults: new { controller = "Sitemap", action = "Index" });
             });
         }
     }


### PR DESCRIPTION
### Context

Hardening the HttpClient handler with more eager timeouts.

### Changes proposed in this pull request

If a request fails due to 5XX or other errors, the HttpClient will wait a certain number of seconds before trying again.

Paired on this with @defong.