### PR TITLE
Reduce importance of training location codes

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
@@ -53,7 +53,7 @@
     if (Model.Course.Campuses.Count() > 0)
     {
     <h3 class="govuk-heading-m">Choose a training location</h3>
-    <p class="govuk-body">You’ll also need to choose a training location and give the relevant training location code.</p>
+    <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
     if (showMap)
     {
       <div id="locations-map" class="google-map--locations"></div>
@@ -61,18 +61,18 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Code</th>
             <th class="govuk-table__header" scope="col">Name</th>
             <th class="govuk-table__header" scope="col">Address</th>
+            <th class="govuk-table__header" scope="col">Code</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           @foreach (var campus in Model.Course.Campuses)
           {
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-!-font-size-24 govuk-!-font-weight-bold">@campus.CampusCode</td>
               <td class="govuk-table__cell">@campus.Name</td>
               <td class="govuk-table__cell">@campus.Location?.Address</td>
+              <td class="govuk-table__cell">@campus.CampusCode</td>
             </tr>
           }
         </tbody>

--- a/src/Assets/Javascript/locations-map.js
+++ b/src/Assets/Javascript/locations-map.js
@@ -48,7 +48,7 @@ const initLocationsMap = () => {
       google.maps.event.addListener(marker, 'click', e => {
         const windowsContent = `
           <div class="search-info-window">
-            <h3 class="govuk-heading-s">${location.name} ${ location.code ? `(${location.code})` : '' }</h3>
+            <h3 class="govuk-heading-s">${location.name}</h3>
             ${ location.address ? `<p class="govuk-body">Address: ${location.address}</p>` : '' }
           </div>
         `


### PR DESCRIPTION
When applying you don't need to enter these codes, only the name of the location.

A code is shown once a location is selected on the application form but not before.

A code might be useful for confirmation once a choice is made in an application, so leave the code in but give it less prominence.

![screen shot 2018-11-16 at 14 40 00](https://user-images.githubusercontent.com/319055/48627845-8d0f3c00-e9ad-11e8-9d91-c22537e46692.png)


### How training locations and their codes look in UCAS Apply

When selecting a location:
![screen shot 2018-11-16 at 14 20 44](https://user-images.githubusercontent.com/319055/48627146-bcbd4480-e9ab-11e8-98fd-b8a67eae2388.png)

After selection:
![screen shot 2018-11-16 at 14 20 50](https://user-images.githubusercontent.com/319055/48627148-bcbd4480-e9ab-11e8-8619-e622030e5db7.png)

In summary:
![screen shot 2018-11-16 at 14 20 58](https://user-images.githubusercontent.com/319055/48627149-bcbd4480-e9ab-11e8-87f4-0262ad6ce16a.png)

