### PR TITLE
Track no provider results in ga

### DIFF
--- a/src/Assets/Javascript/no-results-tracking.js
+++ b/src/Assets/Javascript/no-results-tracking.js
@@ -1,0 +1,29 @@
+function NoResultsTracking($module) {
+  this.$module = $module;
+}
+
+const triggerAnalyticsEvent = (category, action) => {
+  ga("send", "event", {
+    eventCategory: category,
+    eventAction: action,
+    transport: "beacon",
+    nonInteraction: true
+  });
+};
+
+NoResultsTracking.prototype.init = function() {
+  const $module = this.$module;
+
+  if (!$module) {
+    return;
+  }
+
+  const $errorMessage = $module.querySelector("span.govuk-error-message");
+
+  if ($errorMessage) {
+    const searchTerm = document.querySelector("#query").value;
+    triggerAnalyticsEvent("Search by provider: No Results", searchTerm);
+  }
+};
+
+export default NoResultsTracking;

--- a/src/Assets/app.js
+++ b/src/Assets/app.js
@@ -6,6 +6,7 @@ import Toggle from "./Javascript/toggle";
 import { initFormAnalytics, initExternalLinkAnalytics, initNavigationAnalytics } from "./Javascript/analytics.js";
 import ScrollTracking from "./Javascript/scroll-tracking";
 import CopyTracking from "./Javascript/copy-tracking";
+import NoResultsTracking from "./Javascript/no-results-tracking";
 import initAutocomplete from "./Javascript/autocomplete";
 import initGoogleMaps from "./Javascript/map.js";
 import initLocationsMap from "./Javascript/locations-map";
@@ -79,6 +80,9 @@ if (typeof ga !== "undefined") {
   const $page = document.querySelector('[data-module*="ga-track"]');
   new ScrollTracking($page).init();
   new CopyTracking($page).init();
+
+  const $searchInput = document.querySelector('[data-module="track-no-provider-results"]');
+  new NoResultsTracking($searchInput).init();
 } else {
   /* istanbul ignore next */
   console.log("Google Analytics `window.ga` object not found. Skipping analytics.");

--- a/src/Views/Filter/Location.cshtml
+++ b/src/Views/Filter/Location.cshtml
@@ -81,7 +81,7 @@
                   </label>
                 </div>
 
-                <div class="govuk-radios__conditional govuk-radios__conditional--hidden @(Model.Errors.HasError(" query ") ? "form-group--error " : " ")" id="query-container">
+                <div class="govuk-radios__conditional govuk-radios__conditional--hidden @(Model.Errors.HasError(" query ") ? "form-group--error " : " ")" id="query-container" data-module="track-no-provider-results">
                   <div class="form-group">
                     <label class="govuk-label" for="query">
                       School, university or other training provider


### PR DESCRIPTION
### Context
Tracking user interactions

### Changes proposed in this pull request
Send event to GA when a user can't find a provider name with the name of the provider

### Guidance to review
e.g. `Running command: ga("send", "event", {eventCategory: "Search by provider: No Results", eventAction: "Copford Primary", transport: "beacon", nonInteraction: true})`
