### PR TITLE
Geocoder improvements

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -169,7 +169,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
                 return RedirectToAction(isInWizard ? "LocationWizard" : "Location", filter.ToRouteValues());
             }
 
-            var coords = await ResolvePostCodeAsync(filter.lq);
+            var coords = await ResolveAddressAsync(filter.lq);
             if (coords == null)
             {
                 TempData.Put("Errors", new ErrorViewModel("lq", "Postcode, town or city", "We couldn't find this location, please check your input and try again.", Url.Action("Location")));
@@ -312,12 +312,12 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             return View("Provider", filter);
         }
 
-        private async Task<GeocodingResult> ResolvePostCodeAsync(string lq)
+        private async Task<GeocodingResult> ResolveAddressAsync(string lq)
         {
             GeocodingResult coords = null;
             try
             {
-                coords = await _geocoder.ResolvePostCodeAsync(lq);
+                coords = await _geocoder.ResolveAddressAsync(lq);
 
             }
             catch (Exception ex)

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -30,12 +30,12 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             this.client = client;
         }
 
-        public async Task<GeocodingResult> ResolveAddressAsync(string postCode)
+        public async Task<GeocodingResult> ResolveAddressAsync(string address)
         {
             var query = HttpUtility.ParseQueryString(string.Empty);
             query["key"] = apiKey;
             query["region"] = "uk";
-            query["address"] = postCode;
+            query["address"] = address;
 
             var url = "https://maps.googleapis.com/maps/api/geocode/json?" + query.ToString();
             var response = await client.GetAsync(url);
@@ -46,7 +46,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             var status = (string)json.status;
             if (badStatus.Any(x => x.Equals(status, StringComparison.InvariantCultureIgnoreCase)))
             {
-                throw new GoogleMapsApiServiceException($"postCode: {postCode}, url: {url}, content: {content}");
+                throw new GoogleMapsApiServiceException($"address: {address}, url: {url}, content: {content}");
             }
             else
             {
@@ -70,7 +70,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                         .Select(x => x["long_name"].Value<string>())
                         .FirstOrDefault() ?? "";
 
-                    return new GeocodingResult(lat, lng, postCode, formatted, granularity, region);
+                    return new GeocodingResult(lat, lng, address, formatted, granularity, region);
                 }
                 else
                 {

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
         {
             var query = HttpUtility.ParseQueryString(string.Empty);
             query["key"] = apiKey;
-            query["region"] = "uk";
+            query["components"] = "country:uk";
             query["address"] = address;
 
             var url = "https://maps.googleapis.com/maps/api/geocode/json?" + query.ToString();
@@ -53,12 +53,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                 if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
                 {
                     JArray addressComponents = json.results[0].address_components;
-                    var isInUk = addressComponents.Any(IsIndicativeOfUk);
-
-                    if (isInUk == false)
-                    {
-                        return null;
-                    }
 
                     string formatted = json.results[0].formatted_address;
                     double lat = json.results[0].geometry.location.lat;
@@ -114,13 +108,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             }
 
             return res;
-        }
-
-        private static bool IsIndicativeOfUk(JToken addressComponent)
-        {
-            JArray types = (JArray)addressComponent["types"];
-            return types.Any(x => "country" == (string)x) &&
-                (string)addressComponent["short_name"] == "GB";
         }
     }
 }

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -52,14 +52,18 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             {
                 if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase) && ((JArray) json.results).Any())
                 {
-                    JArray addressComponents = json.results[0].address_components;
+                    var result = json.results[0];
+                    var types = result.address_components[0].types;
+                    if (Array.IndexOf(types.ToObject<string[]>(), "country") > -1) {
+                        return null;
+                    }
 
-                    string formatted = json.results[0].formatted_address;
-                    double lat = json.results[0].geometry.location.lat;
-                    double lng = json.results[0].geometry.location.lng;
+                    string formatted = result.formatted_address;
+                    double lat = result.geometry.location.lat;
+                    double lng = result.geometry.location.lng;
 
-                    string granularity = json.results[0].address_components[0].types[0];
-                    string region = ((JArray)json.results[0].address_components)
+                    string granularity = result.address_components[0].types[0];
+                    string region = ((JArray)result.address_components)
                         .Where(x => ((JArray)x["types"]).Any(y => (string)y == "administrative_area_level_2"))
                         .Select(x => x["long_name"].Value<string>())
                         .FirstOrDefault() ?? "";

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             }
             else
             {
-                if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
+                if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase) && ((JArray) json.results).Any())
                 {
                     JArray addressComponents = json.results[0].address_components;
 

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -53,6 +53,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                 if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase) && ((JArray) json.results).Any())
                 {
                     var result = json.results[0];
+
+                    // This is a workaround for when a non-existent gibberish address is fed into the
+                    // geocoder. For some reason, it returns "the UK" as a result. We detect this by looking
+                    // at the types of the first address component
                     var types = result.address_components[0].types;
                     if (Array.IndexOf(types.ToObject<string[]>(), "country") > -1) {
                         return null;

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             this.client = client;
         }
 
-        public async Task<GeocodingResult> ResolvePostCodeAsync(string postCode)
+        public async Task<GeocodingResult> ResolveAddressAsync(string postCode)
         {
             var query = HttpUtility.ParseQueryString(string.Empty);
             query["key"] = apiKey;

--- a/src/Services/IGeocoder.cs
+++ b/src/Services/IGeocoder.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
 {
     public interface IGeocoder
     {
-        Task<GeocodingResult> ResolvePostCodeAsync(string postCode);
+        Task<GeocodingResult> ResolveAddressAsync(string postCode);
         Task<IEnumerable<string>> SuggestLocationsAsync(string input);
     }
 }

--- a/tests/Unit.Tests/Services/Geocoder.Tests.cs
+++ b/tests/Unit.Tests/Services/Geocoder.Tests.cs
@@ -76,14 +76,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         }
 
         [Test]
-        public void NotInUk()
-        {
-            var res = geocoder.ResolveAddressAsync("Sweden");
-            res.Wait();
-            Assert.IsNull(res.Result);
-        }
-
-        [Test]
         public void Autocomplete()
         {
             var res = geocoder.SuggestLocationsAsync("Cambr");

--- a/tests/Unit.Tests/Services/Geocoder.Tests.cs
+++ b/tests/Unit.Tests/Services/Geocoder.Tests.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         public void Throws_GoogleMapsApiServiceException()
         {
             var nullApiGeocoder = new Geocoder("bad_key", new HttpClient());
-            Action act1 = () => nullApiGeocoder.ResolvePostCodeAsync("asdasdasdasd").Wait();
+            Action act1 = () => nullApiGeocoder.ResolveAddressAsync("asdasdasdasd").Wait();
             act1.Should().ThrowExactly<GoogleMapsApiServiceException>();
 
             Action act2 = () => nullApiGeocoder.SuggestLocationsAsync("asdasdasdasd").Wait();
@@ -34,7 +34,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         [Test]
         public void Cambridge()
         {
-            var res = geocoder.ResolvePostCodeAsync("CB4 1FJ");
+            var res = geocoder.ResolveAddressAsync("CB4 1FJ");
             res.Wait();
 
             Assert.IsTrue(res.Result.FormattedLocation.StartsWith("Stott Gardens"));
@@ -54,7 +54,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         public void UkRegionBias()
         {
             // normally resolves to Haverhill, MA, USA. We want the one in Cambridgeshire.
-            var res = geocoder.ResolvePostCodeAsync("Haverhill");
+            var res = geocoder.ResolveAddressAsync("Haverhill");
             res.Wait();
 
             Assert.IsTrue(res.Result.FormattedLocation.StartsWith("Haverhill CB9"));
@@ -70,7 +70,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         [Test]
         public void Nonsense()
         {
-            var res = geocoder.ResolvePostCodeAsync("waeojfawei");
+            var res = geocoder.ResolveAddressAsync("waeojfawei");
             res.Wait();
             Assert.IsNull(res.Result);
         }
@@ -78,7 +78,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
         [Test]
         public void NotInUk()
         {
-            var res = geocoder.ResolvePostCodeAsync("Sweden");
+            var res = geocoder.ResolveAddressAsync("Sweden");
             res.Wait();
             Assert.IsNull(res.Result);
         }


### PR DESCRIPTION
### Context
We are currently using the Google Maps geocoding API in a slightly wrong way. Also some method names and parameter names that don't quite describe what the code does.

### Changes proposed in this pull request
Change the usage of the Google Geocoding API to a more correct way of using it, according to [the documentation](https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering); this is also more in line with how we use the suggest API. This eliminates a case where we get results from outside the UK. It does however introduce another edge case where the the geocoder is passed a gibberish non-existent address.

### Guidance to review
There's **got to** be a more elegant way of doing [this line](https://github.com/DFE-Digital/search-and-compare-ui/blob/999e4174a060f96cd9c471620525cc6423739603/src/Services/Geocoder.cs#L57).
