### PR TITLE
New service `GoogleAnalyticsClient` for server-side analytics

### DIFF
--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -60,8 +60,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                         return null;
                     }
 
-                    ((JArray)json.results).Any();
-
                     string formatted = json.results[0].formatted_address;
                     double lat = json.results[0].geometry.location.lat;
                     double lng = json.results[0].geometry.location.lng;

--- a/src/Services/Geocoder.cs
+++ b/src/Services/Geocoder.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             this.client = client;
         }
 
-        public async Task<Coordinates> ResolvePostCodeAsync(string postCode)
+        public async Task<GeocodingResult> ResolvePostCodeAsync(string postCode)
         {
             var query = HttpUtility.ParseQueryString(string.Empty);
             query["key"] = apiKey;
@@ -43,12 +43,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
             var content = await response.Content.ReadAsStringAsync();
             dynamic json = JsonConvert.DeserializeObject(content);
 
-            var status = (string) json.status;
+            var status = (string)json.status;
             if (badStatus.Any(x => x.Equals(status, StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new GoogleMapsApiServiceException($"postCode: {postCode}, url: {url}, content: {content}");
-            } else {
-                if(status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
+            }
+            else
+            {
+                if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
                 {
                     JArray addressComponents = json.results[0].address_components;
                     var isInUk = addressComponents.Any(IsIndicativeOfUk);
@@ -58,12 +60,22 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
                         return null;
                     }
 
+                    ((JArray)json.results).Any();
+
                     string formatted = json.results[0].formatted_address;
                     double lat = json.results[0].geometry.location.lat;
                     double lng = json.results[0].geometry.location.lng;
 
-                    return new Coordinates(lat, lng, postCode, formatted);
-                } else {
+                    string granularity = json.results[0].address_components[0].types[0];
+                    string region = ((JArray)json.results[0].address_components)
+                        .Where(x => ((JArray)x["types"]).Any(y => (string)y == "administrative_area_level_2"))
+                        .Select(x => x["long_name"].Value<string>())
+                        .FirstOrDefault() ?? "";
+
+                    return new GeocodingResult(lat, lng, postCode, formatted, granularity, region);
+                }
+                else
+                {
                     return null;
                 }
 
@@ -85,18 +97,20 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
 
             var content = await response.Content.ReadAsStringAsync();
             dynamic json = JsonConvert.DeserializeObject(content);
-            var status = (string) json.status;
+            var status = (string)json.status;
 
             var res = new List<string>();
             if (badStatus.Any(x => x.Equals(status, StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new GoogleMapsApiServiceException($"input: {input}, url: {url}, content: {content}");
-            } else {
-                if(status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
+            }
+            else
+            {
+                if (status.Equals(okStatus, StringComparison.InvariantCultureIgnoreCase))
                 {
                     foreach (var prediction in json.predictions)
                     {
-                        res.Add((string) prediction.description);
+                        res.Add((string)prediction.description);
                     }
                 }
             }
@@ -106,9 +120,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
 
         private static bool IsIndicativeOfUk(JToken addressComponent)
         {
-            JArray types = (JArray) addressComponent["types"];
-            return types.Any(x => "country" == (string) x) &&
-                (string) addressComponent["short_name"] == "GB";
+            JArray types = (JArray)addressComponent["types"];
+            return types.Any(x => "country" == (string)x) &&
+                (string)addressComponent["short_name"] == "GB";
         }
     }
 }

--- a/src/Services/GeocodingResult.cs
+++ b/src/Services/GeocodingResult.cs
@@ -1,0 +1,22 @@
+namespace GovUk.Education.SearchAndCompare.UI.Services
+{
+    public class GeocodingResult
+    {
+        public double Latitude { get; }
+        public double Longitude { get; }
+        public string RawInput { get; }
+        public string FormattedLocation { get; }
+        public string Granularity { get; }
+        public string Region { get; }
+
+        public GeocodingResult(double lat, double lng, string rawInput, string formatted, string granularity, string region)
+        {
+            Latitude = lat;
+            Longitude = lng;
+            RawInput = rawInput;
+            FormattedLocation = formatted;
+            Granularity = granularity;
+            Region = region;
+        }
+    }
+}

--- a/src/Services/GoogleAnalyticsClient.cs
+++ b/src/Services/GoogleAnalyticsClient.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GovUk.Education.SearchAndCompare.UI.Services;
+using GovUk.Education.SearchAndCompare.UI.Services.Http;
+
+namespace GovUk.Education.SearchAndCompare.Services
+{
+    public class GoogleAnalyticsClient
+    {
+        private readonly AnalyticsPolicy analyticsPolicy;
+        private HttpClient httpClient;
+        private string tid;
+
+        public GoogleAnalyticsClient(AnalyticsPolicy analyticsPolicy, HttpClient httpClient, string tid)
+        {
+            this.analyticsPolicy = analyticsPolicy;
+            this.httpClient = httpClient;
+            this.tid = "UA-112932657-1"; // to-do: don't hardcode
+        }
+
+        public async Task<int> TrackEvent(string cid, string eventCategory, string eventAction, string eventLabel)
+        {
+            if (analyticsPolicy == AnalyticsPolicy.No)
+            {
+                return 453;
+            }
+
+            var res = await httpClient.PostAsync("http://www.google-analytics.com/collect", new FormUrlEncodedContent(new[] {
+                KeyValuePair.Create("v", "1"),
+                KeyValuePair.Create("tid", tid),
+                KeyValuePair.Create("cid", cid),
+                KeyValuePair.Create("t", "event"),
+                KeyValuePair.Create("ec", eventCategory),
+                KeyValuePair.Create("ea", eventAction),
+                KeyValuePair.Create("el", eventLabel)
+            }));
+
+            return (int)res.StatusCode;
+        }
+    }
+}

--- a/src/Services/GoogleAnalyticsClient.cs
+++ b/src/Services/GoogleAnalyticsClient.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using GovUk.Education.SearchAndCompare.Domain.Client;
 using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Services.Http;
 
@@ -9,24 +10,24 @@ namespace GovUk.Education.SearchAndCompare.Services
     public class GoogleAnalyticsClient
     {
         private readonly AnalyticsPolicy analyticsPolicy;
-        private HttpClient httpClient;
+        private IHttpClient httpClient;
         private string tid;
 
-        public GoogleAnalyticsClient(AnalyticsPolicy analyticsPolicy, HttpClient httpClient, string tid)
+        public GoogleAnalyticsClient(AnalyticsPolicy analyticsPolicy, IHttpClient httpClient, string tid)
         {
             this.analyticsPolicy = analyticsPolicy;
             this.httpClient = httpClient;
-            this.tid = "UA-112932657-1"; // to-do: don't hardcode
+            this.tid = tid;
         }
 
-        public async Task<int> TrackEvent(string cid, string eventCategory, string eventAction, string eventLabel)
+        public async Task TrackEvent(string cid, string eventCategory, string eventAction, string eventLabel)
         {
             if (analyticsPolicy == AnalyticsPolicy.No)
             {
-                return 453;
+                return;
             }
 
-            var res = await httpClient.PostAsync("http://www.google-analytics.com/collect", new FormUrlEncodedContent(new[] {
+            var res = await httpClient.PostAsync(new System.Uri("http://www.google-analytics.com/collect"), new StringContent(new FormUrlEncodedContent(new[] {
                 KeyValuePair.Create("v", "1"),
                 KeyValuePair.Create("tid", tid),
                 KeyValuePair.Create("cid", cid),
@@ -34,9 +35,7 @@ namespace GovUk.Education.SearchAndCompare.Services
                 KeyValuePair.Create("ec", eventCategory),
                 KeyValuePair.Create("ea", eventAction),
                 KeyValuePair.Create("el", eventLabel)
-            }));
-
-            return (int)res.StatusCode;
+            }).ToString()));
         }
     }
 }

--- a/src/Services/IGeocoder.cs
+++ b/src/Services/IGeocoder.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Services
 {
     public interface IGeocoder
     {
-        Task<Coordinates> ResolvePostCodeAsync(string postCode);
+        Task<GeocodingResult> ResolvePostCodeAsync(string postCode);
         Task<IEnumerable<string>> SuggestLocationsAsync(string input);
     }
 }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -20,11 +20,14 @@ using GovUk.Education.SearchAndCompare.UI.Shared.Features;
 using Polly;
 using Polly.Extensions.Http;
 using Polly.Timeout;
+using GovUk.Education.SearchAndCompare.Services;
 
 namespace GovUk.Education.SearchAndCompare.UI
 {
     public class Startup
     {
+        private const string magicStringForGoogleAnalytics = "UA-112932657-1";
+
         private readonly Microsoft.Extensions.Logging.ILogger _logger;
 
         public Startup(IConfiguration configuration, ILoggerFactory logFactory)
@@ -79,6 +82,7 @@ namespace GovUk.Education.SearchAndCompare.UI
             });
 
             services.AddScoped<IFeatureFlags, FeatureFlags>();
+            services.AddScoped<GoogleAnalyticsClient>(p => new GoogleAnalyticsClient(AnalyticsPolicy.FromEnv(), p.GetService<IHttpClient>(), magicStringForGoogleAnalytics));
             services.AddSingleton<IGeocoder>(provider => new Geocoder(Configuration["google_cloud_platform_key_geocoding"], new HttpClient()));
         }
 

--- a/tests/Unit.Tests/Controllers/SubjectGetTests.cs
+++ b/tests/Unit.Tests/Controllers/SubjectGetTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
+using GovUk.Education.SearchAndCompare.Services;
 
 namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
 {
@@ -49,7 +50,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             var mockApi = GetMockApi(_subjectAreas);
             var mockGeocoder = new Mock<IGeocoder>();
 
-            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object, TelemetryClientHelper.GetMocked());
+            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object, TelemetryClientHelper.GetMocked(),
+                new GoogleAnalyticsClient(AnalyticsPolicy.No, null, null));
             var tempDataMock = new Mock<ITempDataDictionary>();
             _filterController.TempData = tempDataMock.Object;
 

--- a/tests/Unit.Tests/Services/Geocoder.Tests.cs
+++ b/tests/Unit.Tests/Services/Geocoder.Tests.cs
@@ -45,6 +45,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
 
             Assert.LessOrEqual(0.1, res.Result.Longitude);
             Assert.GreaterOrEqual(0.2, res.Result.Longitude);
+
+            Assert.AreEqual("postal_code", res.Result.Granularity);
+            Assert.AreEqual("Cambridgeshire", res.Result.Region);
         }
 
         [Test]


### PR DESCRIPTION
### Context

We want for the server to send us usage metrics to GA

### Changes proposed in this pull request

Introduce a Service to send GA telemetry.

Use it to report the type of locality searched (post code, country, town, road, etc etc), as well as the county of search

### Guidance to review

This commit perpetuates some tech debt: Really we should useenvironment
variables for our GA numbers, not hardcode them as we do currently.

We shouldn't resolve this right now though as this would add another moving part to the already
complicated terraform-restore (would require introducing a new environment variable)


