### PR TITLE
Enable high res scale for mini map

### DIFF
--- a/src/Views/Results/Filters/Location.cshtml
+++ b/src/Views/Results/Filters/Location.cshtml
@@ -8,7 +8,7 @@
     @if(Model.Coordinates != null && Model.RadiusOption != null) {
       @Model.loc
       <span class="govuk-caption-m">Within @Model.rad miles of the pin</span>
-      <img src="https://maps.googleapis.com/maps/api/staticmap?key=@(Environment.GetEnvironmentVariable("google_cloud_platform_key_maps"))&center=@(Model.Coordinates.Latitude),@(Model.Coordinates.Longitude)&zoom=@(Model.GetGoogleMapRadius())&size=300x200&markers=@(Model.Coordinates.Latitude),@(Model.Coordinates.Longitude)" alt="Map showing @Model.rad miles of @Model.loc" class="google-map-static"/>
+      <img src="https://maps.googleapis.com/maps/api/staticmap?key=@(Environment.GetEnvironmentVariable("google_cloud_platform_key_maps"))&center=@(Model.Coordinates.Latitude),@(Model.Coordinates.Longitude)&zoom=@(Model.GetGoogleMapRadius())&size=300x200&scale=2&markers=@(Model.Coordinates.Latitude),@(Model.Coordinates.Longitude)" alt="Map showing @Model.rad miles of @Model.loc" class="google-map-static"/>
     } else {
       <text>Across England</text>
     }


### PR DESCRIPTION
### Context
Location - Mini map on high res displays

### Changes proposed in this pull request
Add `&scale=2` to map on search results

### Guidance to review
# Before
<img width="1392" alt="screen shot 2018-11-21 at 14 50 00" src="https://user-images.githubusercontent.com/3071606/48849196-c07f0b80-ed9d-11e8-97cd-a03fadbab514.png">

# After
<img width="1392" alt="screen shot 2018-11-21 at 14 50 32" src="https://user-images.githubusercontent.com/3071606/48849193-beb54800-ed9d-11e8-9b46-c874fc4e6f17.png">