### PR TITLE
Improve abbreviation styles

### DIFF
--- a/src/Assets/Styles/site.scss
+++ b/src/Assets/Styles/site.scss
@@ -16,6 +16,12 @@ $govuk-global-styles: true;
 @import "patterns/filters";
 @import "patterns/pagination";
 
+// Low baseline on NTA causes the dotted line to render oddly
+// when using Chrome. Don't put gaps around descenders in line.
+abbr {
+  text-decoration-skip-ink: none;
+}
+
 // Add brackets around user name in header
 .govuk-header__link--profile {
   @extend .govuk-header__link;


### PR DESCRIPTION
Low baseline on NTA causes the dotted line to render oddly when using Chrome. Don't put gaps around descenders in the underline.

## Before
![screen shot 2018-11-30 at 10 09 30](https://user-images.githubusercontent.com/319055/49283181-fea8b900-f488-11e8-9936-c9e81481c426.png)

## After
![screen shot 2018-11-30 at 10 13 06](https://user-images.githubusercontent.com/319055/49283187-010b1300-f489-11e8-81c9-a856efbedb70.png)
