### PR TITLE
Add feature flag for sen course search

### DIFF
--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -15,6 +15,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         }
 
         public bool Maps => ShouldShow("FEATURE_MAPS");
+        public bool SearchSenCourses => ShouldShow("SEARCH_SEN_COURSES");
 
         public bool ShouldShow(string key)
         {

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -7,5 +7,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
     public interface IFeatureFlags
     {
         bool Maps { get; }
+        bool SearchSenCourses { get; }
     }
 }

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -1,10 +1,14 @@
 @model SubjectFilterViewModel
+@using GovUk.Education.SearchAndCompare.UI.Shared.Features
+@using Microsoft.AspNetCore.Mvc.Razor.Extensions
+@inject IFeatureFlags FeatureFlags
 
 @{
   ViewBag.Title = $"Find courses by subject";
   var selected = Model.FilterModel.SelectedSubjects;
   var isInWizard = ViewBag.IsInWizard == true;
   var errors = ViewBag.Errors as ErrorViewModel;
+  var showSenFilter = FeatureFlags.SearchSenCourses;
 }
 
 <div class="govuk-width-container">
@@ -88,23 +92,25 @@
                 </div>
               }
             </div>
-            <details class="govuk-details" open="@Model.FilterModel.senCourses">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">Do you want to teach special educational needs (SEN)?</span>
-              </summary>
-              <div class="govuk-details__text">
-                <div class="govuk-checkboxes__item">
-                  @{var senCourses = Model.FilterModel.senCourses;}
-                  <input asp-for="@senCourses" class="govuk-checkboxes__input" data-ga-event-form-input="Show SEN courses for the subjects you've selected above"/>
+            @if (showSenFilter == true) {
+              <details class="govuk-details" open="@Model.FilterModel.senCourses">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">Do you want to teach special educational needs (SEN)?</span>
+                </summary>
+                <div class="govuk-details__text">
+                  <div class="govuk-checkboxes__item">
+                    @{var senCourses = Model.FilterModel.senCourses;}
+                    <input asp-for="@senCourses" class="govuk-checkboxes__input" data-ga-event-form-input="Show SEN courses for the subjects you've selected above"/>
 
-                  <label for="senCourses" class="govuk-label govuk-checkboxes__label">
-                    <span class="govuk-checkboxes__label_text">
-                      Show SEN courses for the subjects you've selected above
-                    </span>
-                  </label>
+                    <label for="senCourses" class="govuk-label govuk-checkboxes__label">
+                      <span class="govuk-checkboxes__label_text">
+                        Show SEN courses for the subjects you've selected above
+                      </span>
+                    </label>
+                  </div>
                 </div>
-              </div>
-            </details>
+              </details>
+            }
 
           </fieldset>
           <div class="govuk-form-group">

--- a/src/Views/Filter/Subject.cshtml
+++ b/src/Views/Filter/Subject.cshtml
@@ -100,7 +100,7 @@
                 <div class="govuk-details__text">
                   <div class="govuk-checkboxes__item">
                     @{var senCourses = Model.FilterModel.senCourses;}
-                    <input asp-for="@senCourses" class="govuk-checkboxes__input" data-ga-event-form-input="Show SEN courses for the subjects you've selected above"/>
+                    <input asp-for="@senCourses" class="govuk-checkboxes__input" data-ga-event-form-input="Show SEN courses"/>
 
                     <label for="senCourses" class="govuk-label govuk-checkboxes__label">
                       <span class="govuk-checkboxes__label_text">


### PR DESCRIPTION
### Context
Search for subjects with SEN

### Changes proposed in this pull request
Wrap a feature flag around SEN search checkbox in UI

### Guidance to review
Set `SEARCH_SEN_COURSES` to `true`/`false` then navigate to the subject page. The checkbox should show/hide respectively 
