### PR TITLE
Allow search for SEN when no subjects selected

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             filter.page = null;
 
             var isInWizard = ViewBag.IsInWizard == true;
-            if (!filter.SelectedSubjects.Any())
+            if (!filter.SelectedSubjects.Any() && ! filter.senCourses)
             {
                 TempData.Put("Errors", new ErrorViewModel("subjects", "Please choose at least one subject", null, Url.Action("Subject")));
                 return RedirectToAction(isInWizard ? "SubjectWizard" : "Subject", filter.ToRouteValues());

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             filter.page = null;
 
             var isInWizard = ViewBag.IsInWizard == true;
-            if (!filter.SelectedSubjects.Any() && ! filter.senCourses)
+            if (!filter.SelectedSubjects.Any() && !filter.senCourses)
             {
                 TempData.Put("Errors", new ErrorViewModel("subjects", "Please choose at least one subject", null, Url.Action("Subject")));
                 return RedirectToAction(isInWizard ? "SubjectWizard" : "Subject", filter.ToRouteValues());

--- a/tests/Unit.Tests/Controllers/SubjectGetTests.cs
+++ b/tests/Unit.Tests/Controllers/SubjectGetTests.cs
@@ -65,7 +65,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
         public void GivenSomeSubjects_WhenSubjectGetCalledWithNullSubjectFilter_ThenViewModelHasAllSubjects()
         {
             var inputSubjectFilter = string.Empty;
-            var expectedSelected = new List<int> { 1, 2};
+            var expectedSelected = new List<int> { 1, 2, 3, 4 };
 
             var result = _filterController.SubjectGet(new ResultsFilter { subjects = inputSubjectFilter, SelectedSubjects = expectedSelected}) as ViewResult;
             ViewDataDictionary viewData = result.ViewData;

--- a/tests/Unit.Tests/Controllers/SubjectGetTests.cs
+++ b/tests/Unit.Tests/Controllers/SubjectGetTests.cs
@@ -58,9 +58,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             _filterController = new FilterController(mockApi.Object, mockGeocoder.Object, TelemetryClientHelper.GetMocked(),
                 new GoogleAnalyticsClient(null, null));
             var tempDataMock = new Mock<ITempDataDictionary>();
-            var tempUrlMock = new Mock<IUrlHelper>();
             _filterController.TempData = tempDataMock.Object;
-            _filterController.Url = tempUrlMock.Object;
         }
 
         [Test]

--- a/tests/Unit.Tests/Controllers/SubjectPostTests.cs
+++ b/tests/Unit.Tests/Controllers/SubjectPostTests.cs
@@ -108,6 +108,22 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
 
             _filterController.TempData.Count.Should().Be(0);
         }
+        [Test]
+        public void GivenSubjectAction_WhenSenCoursesNotSelectedWithSubjects_ThenNoErrorMessage()
+        {
+            var inputPage = 1;
+            var expectedSelected = new List<int> { 1, 2 };
+
+            _filterController.TempData = new TempDataDictionary(new DefaultHttpContext(), Mock.Of<ITempDataProvider>());
+            var result = _filterController.SubjectPost(new ResultsFilter
+            {
+                page = inputPage,
+                SelectedSubjects = expectedSelected,
+                senCourses = false
+            }) as ViewResult;
+
+            _filterController.TempData.Count.Should().Be(0);
+        }
         private Mock<ISearchAndCompareApi> GetMockApi(List<SubjectArea> subjectAreas)
         {
             var mockApi = new Mock<ISearchAndCompareApi>();


### PR DESCRIPTION
### Context
This is part of the story to search by SEN courses. Here's the card:
https://trello.com/c/dehAp9dq/574-search-by-send-courses
### Changes proposed in this pull request
This is a change that came out of the review process. You should be able to search for SEN courses even though no subjects are selected.

