### PR TITLE
Rename accredited provider to accredited body

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/Default.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/Default.cshtml
@@ -34,7 +34,7 @@
           <dl class="govuk-list--description">
             @if (!string.IsNullOrEmpty(Model.Course.AccreditingProvider?.Name) && Model.Provider.Name != Model.Course.AccreditingProvider?.Name)
             {
-              <dt class="govuk-list--description__label">Accredited provider</dt>
+              <dt class="govuk-list--description__label">Accredited body</dt>
               <dd>@Model.Course.AccreditingProvider?.Name</dd>
             }
             <dt class="govuk-list--description__label">Financial support</dt>

--- a/shared/Views/Shared/Components/CourseDetails/_AboutTheProvider.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_AboutTheProvider.cshtml
@@ -28,7 +28,7 @@
 
   @if (about_the_accrediting_provider != null)
   {
-    <h3 class="govuk-heading-m">About the accredited provider</h3>
+    <h3 class="govuk-heading-m">About the accredited body</h3>
     @Html.Raw(about_the_accrediting_provider)
   }
 </div>

--- a/src/Views/Results/Display/List.cshtml
+++ b/src/Views/Results/Display/List.cshtml
@@ -57,7 +57,7 @@
         <dd>@item.FundingOptions()</dd>
         @if (!string.IsNullOrEmpty(item.AccreditingProvider?.Name) && item.Provider.Name != item.AccreditingProvider?.Name)
         {
-          <dt class="govuk-list--description__label">Accredited provider</dt>
+          <dt class="govuk-list--description__label">Accredited body</dt>
           <dd>@item.AccreditingProvider.Name</dd>
         }
         @if (item.DistanceAddress == null && item.ProviderLocation != null)


### PR DESCRIPTION
https://trello.com/c/COcKrMG7/787-rename-accredited-provider-to-accredited-body
https://becomingateacher.zendesk.com/agent/tickets/1713

Via TTP - The difference between training provider and accredited provider is unclear.

Try to prevent confusion by removing "provider" from accredited.