### PR TITLE
Add certificate verification file to wwwroot

### DIFF
--- a/src/wwwroot/.well-known/pki-validation/godaddy.html
+++ b/src/wwwroot/.well-known/pki-validation/godaddy.html
@@ -1,0 +1,1 @@
+u643e5nil66e4dqid9nvadcej4


### PR DESCRIPTION
This will be used by the Azure certificates in order to validate that we own the service domain.

This file was force added because `wwwroot/*` is in .gitignore.