### PR TITLE
Fix early career payments bug

### DIFF
--- a/shared/ViewModels/FinanceViewModel.cs
+++ b/shared/ViewModels/FinanceViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
 
 namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
 {
@@ -68,7 +69,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
             }
         }
 
-        public bool HasEarlyCareerPayments => Course.CourseSubjects.Any(cs => cs.Subject.Funding != null && cs.Subject.Funding.EarlyCareerPayments != null);
+        public bool HasEarlyCareerPayments => GetEarlyCareerPaymentsFlag();
+        //public bool HasEarlyCareerPayments {
+        //    get { return GetEarlyCareerPaymentsFlag(); }
+        //}
         public string CurrencyMaxScholarship => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxScholarship);
         public string FormattedMaxScholarship =>  $"Up to {CurrencyMaxScholarship} tax free scholarship while you train";
 
@@ -93,6 +97,19 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
 
             Course = course;
             FeeCaps = feeCaps;
+        }
+        private bool GetEarlyCareerPaymentsFlag()
+        {
+            var hasMaths = this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase));
+            var hasPhysics = this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Physics", StringComparison.InvariantCultureIgnoreCase));
+
+            //do not apply when the course is tagged with both physics and mathematics.
+            if (hasMaths && hasPhysics)
+            {
+                return false;
+            }
+
+            return Course.CourseSubjects.Any(cs => cs.Subject.Funding?.EarlyCareerPayments != null);
         }
     }
 }

--- a/shared/ViewModels/FinanceViewModel.cs
+++ b/shared/ViewModels/FinanceViewModel.cs
@@ -70,9 +70,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
         }
 
         public bool HasEarlyCareerPayments => GetEarlyCareerPaymentsFlag();
-        //public bool HasEarlyCareerPayments {
-        //    get { return GetEarlyCareerPaymentsFlag(); }
-        //}
         public string CurrencyMaxScholarship => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxScholarship);
         public string FormattedMaxScholarship =>  $"Up to {CurrencyMaxScholarship} tax free scholarship while you train";
 

--- a/shared/ViewModels/FinanceViewModel.cs
+++ b/shared/ViewModels/FinanceViewModel.cs
@@ -69,7 +69,20 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
             }
         }
 
-        public bool HasEarlyCareerPayments => GetEarlyCareerPaymentsFlag();
+        public bool HasEarlyCareerPayments
+        {
+            get
+            {
+                //do not apply when the course is tagged with both physics and mathematics.
+                if (this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase))
+                    && this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Physics", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    return false;
+                }
+
+                return Course.CourseSubjects.Any(cs => cs.Subject.Funding?.EarlyCareerPayments != null);
+            }
+        }
         public string CurrencyMaxScholarship => String.Format(System.Globalization.CultureInfo.InvariantCulture, "£{0:n0}", MaxScholarship);
         public string FormattedMaxScholarship =>  $"Up to {CurrencyMaxScholarship} tax free scholarship while you train";
 
@@ -94,19 +107,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewModels
 
             Course = course;
             FeeCaps = feeCaps;
-        }
-        private bool GetEarlyCareerPaymentsFlag()
-        {
-            var hasMaths = this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Mathematics", StringComparison.InvariantCultureIgnoreCase));
-            var hasPhysics = this.Course.CourseSubjects.Any(cs => cs.Subject.Name.Equals("Physics", StringComparison.InvariantCultureIgnoreCase));
-
-            //do not apply when the course is tagged with both physics and mathematics.
-            if (hasMaths && hasPhysics)
-            {
-                return false;
-            }
-
-            return Course.CourseSubjects.Any(cs => cs.Subject.Funding?.EarlyCareerPayments != null);
         }
     }
 }

--- a/tests/Unit.Tests/SharedViewModels/FinanceViewModel.Tests.cs
+++ b/tests/Unit.Tests/SharedViewModels/FinanceViewModel.Tests.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
-using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
 using NUnit.Framework;
 
 namespace SearchAndCompareUI.Tests.Unit.Tests.SharedViewModels
@@ -29,75 +28,62 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.SharedViewModels
             BursaryFirst = 1
         };
 
+        /// <summary>
+        /// This tests the new path and ensures early payments flag is set to false
+        /// where there is a both physics and maths subjects and the early paymants flag
+        /// subjects funding object set to a value or to null
+        /// </summary>
+        /// <param name="subjects">comma separated list of subjects</param>
+        /// <param name="earlyPaymentsFlag">value for flag that normally sets the early payments</param>
         [Test]
-        [TestCase("Physics", "Biology")]
-        [TestCase("Mathematics", "Biology")]
-        [TestCase("Music", "Drama")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Maths_Or_Physics_And_Null_Setting_Should_Be_False(string subject1, string subject2)
-        {
-            var subjects = new List<string> { subject1, subject2 };
-            _subjectFunding.EarlyCareerPayments = null;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
+        [TestCase("Physics,Mathematics", 1)]
+        [TestCase("Mathematics,Physics", 1)]
+        [TestCase("physics,mathematics", 1)]
+        [TestCase("mathematics,physics", 1)]
+        [TestCase("PHYSICS,MATHEMATICS", 1)]
+        [TestCase("MATHEMATICS,PHYSICS", 1)]
+        [TestCase("Physics,Mathematics", null)]
+        [TestCase("Mathematics,Physics", null)]
+        [TestCase("Physics,Mathematics,Frisby Aerodynamics", 1)]
+        [TestCase("Frisby Aerodynamics,Mathematics,Physics", 1)]
+        [TestCase("physics,Frisby Aerodynamics,mathematics", 1)]
+        [TestCase("Physics,Mathematics,Frisby Aerodynamics", null)]
+        [TestCase("Frisby Aerodynamics,Mathematics,Physics", null)]
+        [TestCase("physics,Frisby Aerodynamics,mathematics", null)]
+        [TestCase("music,drama", null)]//test edge cases
+        [TestCase("music,drama,physics", null)]
+        [TestCase("music,drama,mathematics", null)]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Maths_And_Physics_Should_Be_False(string subjects, int? earlyPaymentsFlag)
+        {            
+            _subjectFunding.EarlyCareerPayments = earlyPaymentsFlag;//here is the "not null" setting refered to in the name of the test
+            _emptyCourse.CourseSubjects = SetupSubjects(subjects, _subjectFunding);
+            var financeViewModel = new FinanceViewModel(_emptyCourse, _feeCaps);
+            financeViewModel.HasEarlyCareerPayments.Should().Be(false);
         }
+
+        /// <summary>
+        /// This tests that the happy path still works ok
+        /// </summary>
+        /// <param name="subjects">comma separated list of subjects</param>
+        /// <param name="earlyPaymentsFlag">value for flag that normally sets the early payments</param>
         [Test]
-        [TestCase("Physics", "Mathematics", "Frisby Aerodynamics")]
-        [TestCase("Mathematics", "Physics", "Frisby Aerodynamics")]
-        [TestCase("Frisby Aerodynamics", "Mathematics", "Physics")]
-        [TestCase("Mathematics", "Frisby Aerodynamics", "Physics")]
-        public void EarlyCareerPaymentsFlag_On_Course_Containing_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2, string subject3)
+        [TestCase("Physics,Biology", 123)]
+        [TestCase("Mathematics,Biology", 234)]
+        [TestCase("Music,Drama", 345)]
+        [TestCase("Physics", 345)]
+        [TestCase("Mathematics", 345)]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Not_Null_Setting_Should_Be_True(string subjects, int? earlyPaymentsFlag)
         {
-            var subjects = new List<string> { subject1, subject2, subject3 };
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
+            _subjectFunding.EarlyCareerPayments = earlyPaymentsFlag;
+            _emptyCourse.CourseSubjects = SetupSubjects(subjects, _subjectFunding);
+            var financeViewModel = new FinanceViewModel(_emptyCourse, _feeCaps);
+            financeViewModel.HasEarlyCareerPayments.Should().Be(true);
         }
-        [Test]
-        [TestCase("Physics", "Mathematics")]
-        [TestCase("Mathematics", "Physics")]
-        [TestCase("physics", "mathematics")]
-        [TestCase("mathematics", "physics")]
-        [TestCase("PHYSICS", "MATHEMATICS")]
-        [TestCase("MATHEMATICS", "PHYSICS")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Only_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2)
-        {
-            var subjects = new List<string> {subject1, subject2};
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel( _emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
-        }
-        [Test]
-        [TestCase("Physics", "Biology")]
-        [TestCase("Mathematics", "Biology")]
-        [TestCase("Music", "Drama")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Two_Subjects_And_Not_Null_Setting_Should_Be_True(string subject1, string subject2)
-        {
-            var subjects = new List<string> { subject1, subject2 };
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(true);
-        }
-        [Test]
-        [TestCase("Physics")]
-        [TestCase("Mathematics")]
-        [TestCase("Frisby Aerodynamics")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_One_Subject_And_Not_Null_Setting_Should_Be_True(string subject)
-        {
-            var subjects = new List<string> {subject};
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(true);
-        }
-        private static List<CourseSubject> SetupSUbjects(IEnumerable<string> subjects, SubjectFunding subjectFunding)
+
+        private static List<CourseSubject> SetupSubjects(string subjects, SubjectFunding subjectFunding)
         {
             var subjectId = 1;
-
-            return subjects.Select(subjectName => new CourseSubject
+            return subjects.Split(",").ToList().Select(subjectName => new CourseSubject
                 {
                     SubjectId = subjectId++,
                     Subject = new Subject

--- a/tests/Unit.Tests/SharedViewModels/FinanceViewModel.Tests.cs
+++ b/tests/Unit.Tests/SharedViewModels/FinanceViewModel.Tests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.SharedViewModels
+{
+    [Category("SharedFinanceViewModel")]
+    public class FinanceViewModelTests
+    {
+        private readonly FeeCaps _feeCaps = new FeeCaps {
+            Id = 0,
+            StartYear = 1990,
+            EndYear = 2010,
+            UkFees = 9001,
+            EuFees = 9002,
+            InternationalFees = 800000
+        };
+
+        private readonly Course _emptyCourse = new Course ();
+
+        private readonly SubjectFunding _subjectFunding = new SubjectFunding
+        {
+            Scholarship = 2,
+            BursaryFirst = 1
+        };
+
+        [Test]
+        [TestCase("Physics", "Biology")]
+        [TestCase("Mathematics", "Biology")]
+        [TestCase("Music", "Drama")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Maths_Or_Physics_And_Null_Setting_Should_Be_False(string subject1, string subject2)
+        {
+            var subjects = new List<string> { subject1, subject2 };
+            _subjectFunding.EarlyCareerPayments = null;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Mathematics", "Frisby Aerodynamics")]
+        [TestCase("Mathematics", "Physics", "Frisby Aerodynamics")]
+        [TestCase("Frisby Aerodynamics", "Mathematics", "Physics")]
+        [TestCase("Mathematics", "Frisby Aerodynamics", "Physics")]
+        public void EarlyCareerPaymentsFlag_On_Course_Containing_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2, string subject3)
+        {
+            var subjects = new List<string> { subject1, subject2, subject3 };
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Mathematics")]
+        [TestCase("Mathematics", "Physics")]
+        [TestCase("physics", "mathematics")]
+        [TestCase("mathematics", "physics")]
+        [TestCase("PHYSICS", "MATHEMATICS")]
+        [TestCase("MATHEMATICS", "PHYSICS")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Only_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2)
+        {
+            var subjects = new List<string> {subject1, subject2};
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel( _emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Biology")]
+        [TestCase("Mathematics", "Biology")]
+        [TestCase("Music", "Drama")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Two_Subjects_And_Not_Null_Setting_Should_Be_True(string subject1, string subject2)
+        {
+            var subjects = new List<string> { subject1, subject2 };
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(true);
+        }
+        [Test]
+        [TestCase("Physics")]
+        [TestCase("Mathematics")]
+        [TestCase("Frisby Aerodynamics")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_One_Subject_And_Not_Null_Setting_Should_Be_True(string subject)
+        {
+            var subjects = new List<string> {subject};
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(true);
+        }
+        private static List<CourseSubject> SetupSUbjects(IEnumerable<string> subjects, SubjectFunding subjectFunding)
+        {
+            var subjectId = 1;
+
+            return subjects.Select(subjectName => new CourseSubject
+                {
+                    SubjectId = subjectId++,
+                    Subject = new Subject
+                    {
+                        Id = subjectId,
+                        Name = subjectName,
+                        FundingId = 1,
+                        Funding = subjectFunding
+                    }
+                })
+                .ToList();
+        }
+    }
+}

--- a/tests/Unit.Tests/ViewModels/FinanceViewModel.Tests.cs
+++ b/tests/Unit.Tests/ViewModels/FinanceViewModel.Tests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
 using GovUk.Education.SearchAndCompare.UI.ViewModels;
 using NUnit.Framework;
 
@@ -10,7 +12,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
     [Category("FinanceViewModel")]
     public class FinanceViewModelTests
     {
-        private FeeCaps _feeCaps = new FeeCaps {
+        private readonly FeeCaps _feeCaps = new FeeCaps {
             Id = 0,
             StartYear = 1990,
             EndYear = 2010,
@@ -19,15 +21,12 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
             InternationalFees = 800000
         };
 
-        private Course _emptyCourse = new Course ();
+        private readonly Course _emptyCourse = new Course ();
 
-        private IEnumerable<Subject> MakeSubjects() => new List<Subject> {
-            new Subject {
-                Funding = new SubjectFunding {
-                    Scholarship = 2,
-                    BursaryFirst = 1
-                }
-            }
+        private readonly SubjectFunding _subjectFunding = new SubjectFunding
+        {
+            Scholarship = 2,
+            BursaryFirst = 1
         };
 
         [Test]
@@ -40,6 +39,88 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
         public void CtorThrowsWithNullFeeCaps()
         {
             Assert.Throws(typeof(ArgumentNullException), () => new FinanceViewModel(_emptyCourse, null));
+        }
+
+        [Test]
+        [TestCase("Physics", "Biology")]
+        [TestCase("Mathematics", "Biology")]
+        [TestCase("Music", "Drama")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Maths_Or_Physics_And_Null_Setting_Should_Be_False(string subject1, string subject2)
+        {
+            var subjects = new List<string> { subject1, subject2 };
+            _subjectFunding.EarlyCareerPayments = null;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Mathematics", "Frisby Aerodynamics")]
+        [TestCase("Mathematics", "Physics", "Frisby Aerodynamics")]
+        [TestCase("Frisby Aerodynamics", "Mathematics", "Physics")]
+        [TestCase("Mathematics", "Frisby Aerodynamics", "Physics")]
+        public void EarlyCareerPaymentsFlag_On_Course_Containing_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2, string subject3)
+        {
+            var subjects = new List<string> { subject1, subject2, subject3 };
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Mathematics")]
+        [TestCase("Mathematics", "Physics")]
+        [TestCase("physics", "mathematics")]
+        [TestCase("mathematics", "physics")]
+        [TestCase("PHYSICS", "MATHEMATICS")]
+        [TestCase("MATHEMATICS", "PHYSICS")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Only_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2)
+        {
+            var subjects = new List<string> {subject1, subject2};
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel( _emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(false);
+        }
+        [Test]
+        [TestCase("Physics", "Biology")]
+        [TestCase("Mathematics", "Biology")]
+        [TestCase("Music", "Drama")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_Two_Subjects_And_Not_Null_Setting_Should_Be_True(string subject1, string subject2)
+        {
+            var subjects = new List<string> { subject1, subject2 };
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(true);
+        }
+        [Test]
+        [TestCase("Physics")]
+        [TestCase("Mathematics")]
+        [TestCase("Frisby Aerodynamics")]
+        public void EarlyCareerPaymentsFlag_On_Course_With_One_Course_And_Not_Null_Setting_Should_Be_True(string subject)
+        {
+            var subjects = new List<string> {subject};
+            _subjectFunding.EarlyCareerPayments = 1;
+            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
+            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
+            sut.HasEarlyCareerPayments.Should().Be(true);
+        }
+        private static List<CourseSubject> SetupSUbjects(IEnumerable<string> subjects, SubjectFunding subjectFunding)
+        {
+            var subjectId = 1;
+
+            return subjects.Select(subjectName => new CourseSubject
+                {
+                    SubjectId = subjectId++,
+                    Subject = new Subject
+                    {
+                        Id = subjectId,
+                        Name = subjectName,
+                        FundingId = 1,
+                        Funding = subjectFunding
+                    }
+                })
+                .ToList();
         }
     }
 }

--- a/tests/Unit.Tests/ViewModels/FinanceViewModel.Tests.cs
+++ b/tests/Unit.Tests/ViewModels/FinanceViewModel.Tests.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Models;
-using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
 using GovUk.Education.SearchAndCompare.UI.ViewModels;
 using NUnit.Framework;
 
@@ -12,7 +10,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
     [Category("FinanceViewModel")]
     public class FinanceViewModelTests
     {
-        private readonly FeeCaps _feeCaps = new FeeCaps {
+        private FeeCaps _feeCaps = new FeeCaps
+        {
             Id = 0,
             StartYear = 1990,
             EndYear = 2010,
@@ -21,12 +20,15 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
             InternationalFees = 800000
         };
 
-        private readonly Course _emptyCourse = new Course ();
+        private Course _emptyCourse = new Course();
 
-        private readonly SubjectFunding _subjectFunding = new SubjectFunding
-        {
-            Scholarship = 2,
-            BursaryFirst = 1
+        private IEnumerable<Subject> MakeSubjects() => new List<Subject> {
+            new Subject {
+                Funding = new SubjectFunding {
+                    Scholarship = 2,
+                    BursaryFirst = 1
+                }
+            }
         };
 
         [Test]
@@ -39,88 +41,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewModels
         public void CtorThrowsWithNullFeeCaps()
         {
             Assert.Throws(typeof(ArgumentNullException), () => new FinanceViewModel(_emptyCourse, null));
-        }
-
-        [Test]
-        [TestCase("Physics", "Biology")]
-        [TestCase("Mathematics", "Biology")]
-        [TestCase("Music", "Drama")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Maths_Or_Physics_And_Null_Setting_Should_Be_False(string subject1, string subject2)
-        {
-            var subjects = new List<string> { subject1, subject2 };
-            _subjectFunding.EarlyCareerPayments = null;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
-        }
-        [Test]
-        [TestCase("Physics", "Mathematics", "Frisby Aerodynamics")]
-        [TestCase("Mathematics", "Physics", "Frisby Aerodynamics")]
-        [TestCase("Frisby Aerodynamics", "Mathematics", "Physics")]
-        [TestCase("Mathematics", "Frisby Aerodynamics", "Physics")]
-        public void EarlyCareerPaymentsFlag_On_Course_Containing_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2, string subject3)
-        {
-            var subjects = new List<string> { subject1, subject2, subject3 };
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
-        }
-        [Test]
-        [TestCase("Physics", "Mathematics")]
-        [TestCase("Mathematics", "Physics")]
-        [TestCase("physics", "mathematics")]
-        [TestCase("mathematics", "physics")]
-        [TestCase("PHYSICS", "MATHEMATICS")]
-        [TestCase("MATHEMATICS", "PHYSICS")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Only_Maths_And_Physics_And_Not_Null_Setting_Should_Be_False(string subject1, string subject2)
-        {
-            var subjects = new List<string> {subject1, subject2};
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel( _emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(false);
-        }
-        [Test]
-        [TestCase("Physics", "Biology")]
-        [TestCase("Mathematics", "Biology")]
-        [TestCase("Music", "Drama")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_Two_Subjects_And_Not_Null_Setting_Should_Be_True(string subject1, string subject2)
-        {
-            var subjects = new List<string> { subject1, subject2 };
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(true);
-        }
-        [Test]
-        [TestCase("Physics")]
-        [TestCase("Mathematics")]
-        [TestCase("Frisby Aerodynamics")]
-        public void EarlyCareerPaymentsFlag_On_Course_With_One_Course_And_Not_Null_Setting_Should_Be_True(string subject)
-        {
-            var subjects = new List<string> {subject};
-            _subjectFunding.EarlyCareerPayments = 1;
-            _emptyCourse.CourseSubjects = SetupSUbjects(subjects, _subjectFunding);
-            var sut = new GovUk.Education.SearchAndCompare.UI.Shared.ViewModels.FinanceViewModel(_emptyCourse, _feeCaps);
-            sut.HasEarlyCareerPayments.Should().Be(true);
-        }
-        private static List<CourseSubject> SetupSUbjects(IEnumerable<string> subjects, SubjectFunding subjectFunding)
-        {
-            var subjectId = 1;
-
-            return subjects.Select(subjectName => new CourseSubject
-                {
-                    SubjectId = subjectId++,
-                    Subject = new Subject
-                    {
-                        Id = subjectId,
-                        Name = subjectName,
-                        FundingId = 1,
-                        Funding = subjectFunding
-                    }
-                })
-                .ToList();
         }
     }
 }


### PR DESCRIPTION
### Context
Find currently provides false advertisements around the financial incentives for Physics with Maths courses
Here is the card:
https://trello.com/c/SJft9gU5/835-early-careers-payments-content-fix-for-physics-with-maths-courses
### Changes proposed in this pull request
Changes to the FinanceViewModel in SearchAndCompareUi.Shared.
Plus new tests which would have flushed out the bug.
### Guidance to review
Confusingly there is another FinanceViewModel with tests that appears not to be used anymore. This should be removed in another task
Here is a screenshot of the new finance incentive section:

![image](https://user-images.githubusercontent.com/6573457/51031211-be624d80-1593-11e9-822b-6bba7cd2d742.png)
