### PR TITLE
Fully qualify deploy git refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
         - "./travis-build.sh --quiet verify"
       deploy:
         - provider: script
-          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-dev-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-dev-search-and-compare-ui-app.git && git push --force deploy HEAD:master
+          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-dev-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-dev-search-and-compare-ui-app.git && git push --force deploy HEAD:refs/heads/master
           on: master
         - provider: script
-          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-staging-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-staging-search-and-compare-ui-app.git && git push --force deploy HEAD:master
+          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-staging-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-staging-search-and-compare-ui-app.git && git push --force deploy HEAD:refs/heads/master
           on: staging
         - provider: script
-          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-2018-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-prod-2018-search-and-compare-ui-app.git && git push --force deploy HEAD:master
+          script: git fetch --unshallow && git remote add deploy https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-2018-search-and-compare-ui-app.scm.azurewebsites.net:443/bat-prod-2018-search-and-compare-ui-app.git && git push --force deploy HEAD:refs/heads/master
           on: production
         - provider: script
           skip_cleanup: true


### PR DESCRIPTION
Without the refs/heads/master you can't deploy to an empty appservice.

The error is:

> error: unable to push to unqualified destination: master
> The destination refspec neither matches an existing ref on the remote
nor

Now matches https://github.com/DFE-Digital/search-and-compare-api/blob/master/.travis.yml#L25