### PR TITLE
Add a meta description

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -9,6 +9,7 @@
     <title>@(ViewBag.Title ?? "Welcome to GOV.UK")</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0b0c0c" />
+    <meta name="description" content="A service to help graduates find the most relevant postgraduate teacher training courses." />
 
     <link rel="shortcut icon" href="~/images/favicon.ico" type="image/x-icon" asp-append-version="true" />
     <link rel="mask-icon" href="~/images/govuk-mask-icon.svg" color="#0b0c0c" asp-append-version="true" />


### PR DESCRIPTION
This should give the service a better blurb in search engine results.
Currently the cookie text is being used. 

Ideally the description would be different for each page. But this is better than nothing.

## Before

![screen shot 2019-01-11 at 15 46 23](https://user-images.githubusercontent.com/319055/51044058-1dd25480-15b8-11e9-807a-e17051d545f5.png)