### PR TITLE
Remove conditional around training locations map

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
@@ -8,11 +8,6 @@
 @using Microsoft.AspNetCore.Mvc.Razor.Extensions
 @inject IFeatureFlags FeatureFlags
 
-@{
-  var showMap = ViewBag.showMap is bool showMapBool && showMapBool;
-}
-
-
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
   @if (Model.Course.HasVacancies == false)
@@ -54,10 +49,7 @@
     {
     <h3 class="govuk-heading-m">Choose a training location</h3>
     <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
-    if (showMap)
-    {
-      <div id="locations-map" class="google-map--locations"></div>
-    }
+    <div id="locations-map" class="google-map--locations"></div>
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -81,22 +73,19 @@
   }
 </div>
 
-@if (showMap)
-{
-  <script>
-    window.trainingLocations = [
-      @foreach (var campus in Model.Course.Campuses)
-      {
-        <text>
-          {
-            "code": "@campus.CampusCode",
-            "name": "@campus.Name",
-            "lat": @(campus.Location == null ? Model.Course.ProviderLocation.Latitude : campus.Location.Latitude),
-            "lng": @(campus.Location == null ? Model.Course.ProviderLocation.Longitude : campus.Location.Longitude),
-            "address": "@campus.Location?.Address"
-          },
-        </text>
-      }
-    ]
-  </script>
-}
+<script>
+  window.trainingLocations = [
+    @foreach (var campus in Model.Course.Campuses)
+    {
+      <text>
+        {
+          "code": "@campus.CampusCode",
+          "name": "@campus.Name",
+          "lat": @(campus.Location == null ? Model.Course.ProviderLocation.Latitude : campus.Location.Latitude),
+          "lng": @(campus.Location == null ? Model.Course.ProviderLocation.Longitude : campus.Location.Longitude),
+          "address": "@campus.Location?.Address"
+        },
+      </text>
+    }
+  ]
+</script>

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -17,9 +17,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         }
 
         [HttpGet("course/{providerCode}/{courseCode}", Name = "Course")]
-        public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter, bool previewMap)
+        public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter)
         {
-            ViewBag.showMap = previewMap;
             var course = _api.GetCourse(providerCode, courseCode);
             var feeCaps = _api.GetFeeCaps();
 

--- a/src/Views/Course/Index.cshtml
+++ b/src/Views/Course/Index.cshtml
@@ -2,14 +2,10 @@
 
 @{
   ViewBag.Title = $"{Model.Course.Name} ({Model.Course.ProgrammeCode}) with {Model.Provider.Name}";
-  var showMap = ViewBag.showMap is bool showMapBool && showMapBool;
 }
 
-@if (showMap)
-{
-  @section bodyEnd {
-    <script src="https://maps.googleapis.com/maps/api/js?key=@(Environment.GetEnvironmentVariable("google_cloud_platform_key_maps"))&callback=initLocationsMap" async defer></script>
-  }
+@section bodyEnd {
+  <script src="https://maps.googleapis.com/maps/api/js?key=@(Environment.GetEnvironmentVariable("google_cloud_platform_key_maps"))&callback=initLocationsMap" async defer></script>
 }
 
 @await Component.InvokeAsync("CourseDetails", new { course = Model })

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             mockApi.Setup(x=>x.GetFeeCaps()).Returns(new List<FeeCaps>());
             var controller = new CourseController(mockApi.Object);
 
-            var res = controller.Index("abc", "def", new ResultsFilter(), false);
+            var res = controller.Index("abc", "def", new ResultsFilter());
 
             Assert.That(res is StatusCodeResult);
             Assert.AreEqual(404, (res as StatusCodeResult).StatusCode);
@@ -35,7 +35,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             mockApi.Setup(x => x.GetFeeCaps()).Returns(new List<FeeCaps> {new FeeCaps {UkFees = 123}}).Verifiable();
             var controller = new CourseController(mockApi.Object);
 
-            var res = controller.Index("abc", "def", new ResultsFilter(), false);
+            var res = controller.Index("abc", "def", new ResultsFilter());
 
             Assert.That(res is ViewResult);
             Assert.That((res as ViewResult).Model is CourseDetailsViewModel);


### PR DESCRIPTION
### Context
Training location map

### Changes proposed in this pull request
Ensure map for training locations is present for everyone

### Guidance to review
View details page for any course and the map should appear

# After
<img width="850" alt="screen shot 2019-01-29 at 11 34 42" src="https://user-images.githubusercontent.com/3071606/51905718-e3d7bf80-23b9-11e9-8922-b80e109b5ce3.png">
