### PR TITLE
Changed nuget package reference

### DIFF
--- a/shared/SearchAndCompareUi.Shared.csproj
+++ b/shared/SearchAndCompareUi.Shared.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.1.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
   </ItemGroup>
 

--- a/shared/SearchAndCompareUi.Shared.csproj
+++ b/shared/SearchAndCompareUi.Shared.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
   </ItemGroup>
 

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.1.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.1.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2-service-unavailable-when-api-404.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context
This is the bug whereby a "Service Unavailable" page is shown when a non-existent course is requested.
Here is the card:
https://trello.com/c/cjI2ies3/575-find-showing-503-service-unavailable-when-the-api-returns-404
### Changes proposed in this pull request
All nuget package references have been changed to look at the new ApiClient.
### Guidance to review
As soon as the ApiClient changes have been approved then the nuget package reference will be changed to look at 0.11.2 rather than 0.11.2-service-unavailable-when-api-404.3

![image](https://user-images.githubusercontent.com/6573457/51912634-b2b4ba80-23cc-11e9-914e-27022e6dae3a.png)


