### PR TITLE
Remove map bounding on preview map

### DIFF
--- a/src/Assets/Javascript/locations-map.js
+++ b/src/Assets/Javascript/locations-map.js
@@ -61,10 +61,8 @@ const initLocationsMap = () => {
     const popup = new Popup(latLng, closedContent, openContent);
     popup.setMap(map);
 
-    // Extend the bounds by the first 5 locations so we get a decent number as part of the first view.
-    if (i < 5) {
-      bounds.extend(latLng);
-    }
+    // Extend the bounds by the locations so we get a decent number as part of the first view.
+    bounds.extend(latLng);
   }
 
   // Use provider address to center and zoom when only one location

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8144,7 +8144,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },


### PR DESCRIPTION
This is a feature that was integrated for the fullscreen map iteration and was ported over to the smaller map used in the course page. It's not necessary and can lead us to showing a map without all the training locations, as pointed out by @fofr.

## Before

<img width="675" alt="screenshot 2019-01-31 at 13 30 36" src="https://user-images.githubusercontent.com/1650875/52057243-6c8e6100-255c-11e9-8441-9de4384f2414.png">

## After (the same)

<img width="676" alt="screenshot 2019-01-31 at 13 30 22" src="https://user-images.githubusercontent.com/1650875/52057247-7021e800-255c-11e9-8c1e-7d91150648bd.png">
