### PR TITLE
Duplicate parameters break social media sharing

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -200,7 +200,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult LocationWizardGet(ResultsFilter filter)
         {
             ViewBag.IsInWizard = true;
-            filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+
             return LocationGet(filter);
         }
 
@@ -263,8 +265,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult QualificationPost(ResultsFilter model)
         {
             model.page = null;
-            model.qualification = model.qualification.Any() ? model.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
-
+            //model.qualification = model.qualification.Any() ? model.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            //model.qualifications = ! string.IsNullOrWhiteSpace(model.qualifications) ? model.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+            model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q)))  : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+            model.qualification = new List<QualificationOption>();
             return RedirectToAction("Index", "Results", model.ToRouteValues());
         }
 

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -265,10 +265,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult QualificationPost(ResultsFilter model)
         {
             model.page = null;
-            //model.qualification = model.qualification.Any() ? model.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
-            //model.qualifications = ! string.IsNullOrWhiteSpace(model.qualifications) ? model.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+            //put the posted qualifications into a comma separated string
             model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q)))  : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
-            model.qualification = new List<QualificationOption>();
+            model.qualification = new List<QualificationOption>();//remove this from the url
             return RedirectToAction("Index", "Results", model.ToRouteValues());
         }
 

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -54,8 +54,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             {
                 throw new Exception("Failed to retrieve subject list from api");
             }
-            filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
-
+            //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
             FilteredList<Subject> filteredSubjects;
             if (filter.SelectedSubjects.Count > 0)
             {
@@ -92,7 +92,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult ResultsMap(ResultsFilter filter)
         {
             var subjects = _api.GetSubjects();
-            filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
+            filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
 
             FilteredList<Subject> filteredSubjects;
             if (filter.SelectedSubjects.Count > 0)

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -54,7 +54,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
             {
                 throw new Exception("Failed to retrieve subject list from api");
             }
-            //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
             filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
             FilteredList<Subject> filteredSubjects;
             if (filter.SelectedSubjects.Count > 0)
@@ -92,7 +91,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult ResultsMap(ResultsFilter filter)
         {
             var subjects = _api.GetSubjects();
-            //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
             filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
 
             FilteredList<Subject> filteredSubjects;

--- a/src/Filters/ResultsFilter.cs
+++ b/src/Filters/ResultsFilter.cs
@@ -150,10 +150,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public QueryFilter ToQueryFilter()
         {
             byte resQualification = 0;
-            foreach (var qualstr in this.qualifications.Split(","))
+
+            if (!string.IsNullOrWhiteSpace(this.qualifications))
             {
-                var qual = (int)Enum.Parse(typeof(QualificationOption), qualstr);
-                resQualification ^= (byte) qual;
+                foreach (var qualstr in this.qualifications.Split(","))
+                {
+                    var qual = (int)Enum.Parse(typeof(QualificationOption), qualstr);
+                    resQualification ^= (byte)qual;
+                }
             }
 
             return new QueryFilter

--- a/src/Filters/ResultsFilter.cs
+++ b/src/Filters/ResultsFilter.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public bool parttime { get; set; }
         public bool hasvacancies { get; set; }
         public bool senCourses { get; set; }
-        public string qualifications { get; set; }
+        public string qualifications { get; set; }//needed for qualification.cshtml page
         public IList<QualificationOption> qualification { get; set; }
 
         public List<int> SelectedSubjects
@@ -150,10 +150,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public QueryFilter ToQueryFilter()
         {
             byte resQualification = 0;
-            //foreach (var qual in this.qualification)
-            //{
-            //    resQualification ^= (byte)qual;
-            //}
             foreach (var qualstr in this.qualifications.Split(","))
             {
                 var qual = (int)Enum.Parse(typeof(QualificationOption), qualstr);
@@ -217,7 +213,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                //qualification = this.qualification,
                 qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
@@ -246,7 +241,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                //qualification = this.qualification,
                 qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
@@ -274,7 +268,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                //qualification = this.qualification,
                 qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
@@ -311,7 +304,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                //qualification = this.qualification,
                 qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
@@ -342,7 +334,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                //qualification = this.qualification,
                 qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
@@ -353,9 +344,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
 
         public IEnumerable<string> GetQualificationStrings()
         {
-            //if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts)
-            //    && qualification.Any(x => x == QualificationOption.QtsOnly)
-            //    && qualification.Any(x => x == QualificationOption.Other))
             if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.PgdePgceWithQts))
                 && qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.QtsOnly))
                 && qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.Other))
@@ -365,17 +353,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
             }
             else
             {
-                //if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts))
                 if(qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.PgdePgceWithQts)))
                 {
                     yield return "PGCE (or PGDE) with QTS";
                 }
-                //if (qualification.Any(x => x == QualificationOption.QtsOnly))
                 if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.QtsOnly)))
                 {
                     yield return "QTS only";
                 }
-                //if (qualification.Any(x => x == QualificationOption.Other))
                 if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.Other)))
                 {
                     yield return "Further Education (PGCE or PGDE without QTS)";

--- a/src/Filters/ResultsFilter.cs
+++ b/src/Filters/ResultsFilter.cs
@@ -16,6 +16,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public ResultsFilter()
         {
             qualification = new List<QualificationOption>();
+            qualifications = null;
             this.hasvacancies = true;
         }
         public int? page { get; set; }
@@ -53,6 +54,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public bool parttime { get; set; }
         public bool hasvacancies { get; set; }
         public bool senCourses { get; set; }
+        public string qualifications { get; set; }
         public IList<QualificationOption> qualification { get; set; }
 
         public List<int> SelectedSubjects
@@ -148,9 +150,14 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
         public QueryFilter ToQueryFilter()
         {
             byte resQualification = 0;
-            foreach (var qual in this.qualification)
+            //foreach (var qual in this.qualification)
+            //{
+            //    resQualification ^= (byte)qual;
+            //}
+            foreach (var qualstr in this.qualifications.Split(","))
             {
-                resQualification ^= (byte)qual;
+                var qual = (int)Enum.Parse(typeof(QualificationOption), qualstr);
+                resQualification ^= (byte) qual;
             }
 
             return new QueryFilter
@@ -191,6 +198,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 offlng,
                 offlat,
                 qualification,
+                qualifications,
                 fulltime,
                 parttime,
                 hasvacancies,
@@ -209,7 +217,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                qualification = this.qualification,
+                //qualification = this.qualification,
+                qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
                 hasvacancies = this.hasvacancies,
@@ -237,7 +246,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                qualification = this.qualification,
+                //qualification = this.qualification,
+                qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
                 hasvacancies = this.hasvacancies,
@@ -264,7 +274,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                qualification = this.qualification,
+                //qualification = this.qualification,
+                qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
                 hasvacancies = this.hasvacancies,
@@ -300,7 +311,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                qualification = this.qualification,
+                //qualification = this.qualification,
+                qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
                 hasvacancies = this.hasvacancies,
@@ -330,7 +342,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
                 zoomlevel = this.zoomlevel,
                 offlng = this.offlng,
                 offlat = this.offlat,
-                qualification = this.qualification,
+                //qualification = this.qualification,
+                qualifications = this.qualifications,
                 fulltime = this.fulltime,
                 parttime = this.parttime,
                 hasvacancies = this.hasvacancies,
@@ -340,23 +353,30 @@ namespace GovUk.Education.SearchAndCompare.UI.Filters
 
         public IEnumerable<string> GetQualificationStrings()
         {
-            if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts)
-                && qualification.Any(x => x == QualificationOption.QtsOnly)
-                && qualification.Any(x => x == QualificationOption.Other))
+            //if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts)
+            //    && qualification.Any(x => x == QualificationOption.QtsOnly)
+            //    && qualification.Any(x => x == QualificationOption.Other))
+            if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.PgdePgceWithQts))
+                && qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.QtsOnly))
+                && qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.Other))
+            )
             {
                 yield return "All qualifications";
             }
             else
             {
-                if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts))
+                //if (qualification.Any(x => x == QualificationOption.PgdePgceWithQts))
+                if(qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.PgdePgceWithQts)))
                 {
                     yield return "PGCE (or PGDE) with QTS";
                 }
-                if (qualification.Any(x => x == QualificationOption.QtsOnly))
+                //if (qualification.Any(x => x == QualificationOption.QtsOnly))
+                if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.QtsOnly)))
                 {
                     yield return "QTS only";
                 }
-                if (qualification.Any(x => x == QualificationOption.Other))
+                //if (qualification.Any(x => x == QualificationOption.Other))
+                if (qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.Other)))
                 {
                     yield return "Further Education (PGCE or PGDE without QTS)";
                 }

--- a/src/Views/Filter/Qualification.cshtml
+++ b/src/Views/Filter/Qualification.cshtml
@@ -21,7 +21,7 @@
             <div class="govuk-form-group">
               <div class="govuk-checkboxes">
                 <div class="govuk-checkboxes__item">
-                  <input id="applyFilter-qts-only" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.QtsOnly" checked="@Model.qualification.Any(x => x == QualificationOption.QtsOnly)" data-ga-event-form-input="QTS only">
+                  <input id="applyFilter-qts-only" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.QtsOnly" checked="@Model.qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.QtsOnly))" data-ga-event-form-input="QTS only">
                   <label for="applyFilter-qts-only" class="govuk-label govuk-checkboxes__label">
                     <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                       QTS only
@@ -39,7 +39,7 @@
                 </div>
 
                 <div class="govuk-checkboxes__item">
-                  <input id="applyFilter-pgce-pgde-with-qts" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.PgdePgceWithQts" checked="@Model.qualification.Any(x => x == QualificationOption.PgdePgceWithQts)" data-ga-event-form-input="PGCE / PGDE with QTS">
+                  <input id="applyFilter-pgce-pgde-with-qts" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.PgdePgceWithQts" checked="@Model.qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.PgdePgceWithQts))" data-ga-event-form-input="PGCE / PGDE with QTS">
                   <label for="applyFilter-pgce-pgde-with-qts" class="govuk-label govuk-checkboxes__label">
                     <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                       PGCE (or PGDE) with QTS
@@ -59,7 +59,7 @@
                 </div>
 
                 <div class="govuk-checkboxes__item">
-                  <input id="applyFilter-other" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.Other" checked="@Model.qualification.Any(x => x == QualificationOption.Other)" data-ga-event-form-input="Further Education">
+                  <input id="applyFilter-other" class="govuk-checkboxes__input" type="checkbox" name="qualification" value="@QualificationOption.Other" checked="@Model.qualifications.Contains(Enum.GetName(typeof(QualificationOption), QualificationOption.Other))" data-ga-event-form-input="Further Education">
                   <label for="applyFilter-other" class="govuk-label govuk-checkboxes__label">
                     <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">
                       Further education (PGCE or PGDE without QTS)


### PR DESCRIPTION
### Context
This is the story for a change in the search results url where duplicate search parameters break social media link sharing. Here is the card:
https://trello.com/c/izqiESsO/774-duplicate-parameters-break-social-media-link-sharing

### Changes proposed in this pull request
The ResultsFilter class that gets passed into the endpoint has a collection of enums for the qualifications. This is the cause of the problem. This collection has been replaced by a string which now holds a comma-separated list of the qualification enums and this is now gives us the url we want. This comma-separated list now drives the search and filter mechanism.
### Guidance to review
I needed to re-instate the collection of enums solely for the purpose of taking user input in the qualification.cshtml page. When this page is posted then the enums collection set by the user is put into the new comma-separated string. This feels a little clunky but may be the best way to do this? Comments welcome!!
