### PR TITLE
Changed nuget version to match Api

### DIFF
--- a/shared/SearchAndCompareUi.Shared.csproj
+++ b/shared/SearchAndCompareUi.Shared.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.3.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
   </ItemGroup>
 

--- a/shared/Views/Shared/Components/CourseDetails/_Qualification.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_Qualification.cshtml
@@ -6,7 +6,7 @@
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters;
 @using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
 
-@if(Model.Course.IncludesPgce.Equals(IncludesPgce.No))
+@if(Model.Course.IncludesPgce.Equals(IncludesPgce.QtsOnly))
 
 {
   <details class="govuk-details">
@@ -26,7 +26,7 @@
     </div>
   </details>
 }
-else if (Model.Course.IncludesPgce.Equals(IncludesPgce.Yes))
+else if (Model.Course.IncludesPgce.Equals(IncludesPgce.QtsWithPgce))
 {
   <details class="govuk-details">
     <summary class="govuk-details__summary">

--- a/src/SearchAndCompareUi.csproj
+++ b/src/SearchAndCompareUi.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.3.*" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />

--- a/tests/SearchAndCompareUI.Tests.csproj
+++ b/tests/SearchAndCompareUI.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="nunit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.2.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.ApiClient" Version="0.11.3.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context
There was a version mismatch causing the deployment to fail
### Changes proposed in this pull request
Changed nuget version reference.
Updated Qualification.cshtml page to match new type names


