### PR TITLE
[1162] Log swallowed exceptions from suggested search

### DIFF
--- a/src/ViewComponents/SuggestedSearch.cs
+++ b/src/ViewComponents/SuggestedSearch.cs
@@ -4,22 +4,23 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.SearchAndCompare.UI.ViewModels;
-using GovUk.Education.SearchAndCompare.Domain.Filters;
 using GovUk.Education.SearchAndCompare.Domain.Filters.Enums;
 using GovUk.Education.SearchAndCompare.Domain.Client;
-using GovUk.Education.SearchAndCompare.Domain.Data;
-using GovUk.Education.SearchAndCompare.ViewFormatters;
 using GovUk.Education.SearchAndCompare.UI.Filters;
 using GovUk.Education.SearchAndCompare.UI.Filters.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.SearchAndCompare.UI.ViewComponents
 {
     public class SuggestedSearch :ViewComponent
     {
         private readonly ISearchAndCompareApi _api;
-        public SuggestedSearch(ISearchAndCompareApi api)
+        private readonly ILogger<SuggestedSearch> _logger;
+
+        public SuggestedSearch(ISearchAndCompareApi api, ILogger<SuggestedSearch> logger)
         {
             _api = api;
+            _logger = logger;
         }
 
         public Task<IViewComponentResult> InvokeAsync(ResultsViewModel original, int maxResult)
@@ -115,7 +116,7 @@ namespace GovUk.Education.SearchAndCompare.UI.ViewComponents
                     }
                 }
             } catch (Exception e) {
-                // Production hotfix.
+                _logger.LogError("Suggested search failed, exception swallowed to avoid 500 error to user.", e);
             }
 
             return results.ToList();

--- a/tests/Unit.Tests/ViewComponents/SuggestedSearchTests.cs
+++ b/tests/Unit.Tests/ViewComponents/SuggestedSearchTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.SearchAndCompare.UI.ViewComponents;
 using GovUk.Education.SearchAndCompare.UI.ViewModels;
 using GovUk.Education.SearchAndCompare.ViewModels;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
@@ -30,7 +31,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewComponents
             var mockApi = new Mock<ISearchAndCompareApi>();
             mockApi.Setup(x => x.GetCoursesTotalCount(It.IsAny<QueryFilter>())).Returns(new TotalCountResult());
 
-            var res = new SuggestedSearch(mockApi.Object)
+            var res = new SuggestedSearch(mockApi.Object, new Mock<ILogger<SuggestedSearch>>().Object)
                 .InvokeAsync(empty, 100).Result;
 
             Assert.That(res is ViewViewComponentResult);


### PR DESCRIPTION
This is a follow-up to an edge-case failure in production that resulted
in the whole results page failing. Having patched it to swallow
exceptions to improve the user experience we now want to be made aware
if this is happening so we can take action. These logs can be pushed
into app insights etc to create alerting.



