### PR TITLE
[1164] Fix 500 error on the qualifications page

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -257,6 +257,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Qualification")]
         public IActionResult QualificationGet(ResultsFilter model)
         {
+            // Put the posted qualifications into a comma separated string
+            model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q))) : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+            model.qualification = new List<QualificationOption>(); // Remove this from the url
             return View(model);
         }
 
@@ -265,9 +268,9 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         public IActionResult QualificationPost(ResultsFilter model)
         {
             model.page = null;
-            //put the posted qualifications into a comma separated string
-            model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q)))  : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
-            model.qualification = new List<QualificationOption>();//remove this from the url
+            // Put the posted qualifications into a comma separated string
+            model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q))) : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
+            model.qualification = new List<QualificationOption>(); // Remove this from the url
             return RedirectToAction("Index", "Results", model.ToRouteValues());
         }
 


### PR DESCRIPTION
The offending URL contains separate `qualification` parameters as opposed to the comma separated `qualifications` string that the POST uses now. The frontend template can't deal with it, the POST knows how to deal with it, so just copy over the logic into the GET. Yes, this is a bit of repetition but it's only the second instance and I think it's fine.