### PR TITLE
1140 fix multi subject funding

### DIFF
--- a/shared/ViewFormatters/CourseExtensions.cs
+++ b/shared/ViewFormatters/CourseExtensions.cs
@@ -10,6 +10,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters
 {
     public static class CourseExtensions
     {
+        public const string FundingOption_Salary = "Salary";
+        public const string FundingOption_Scholarship = "Scholarship, bursary or student finance if you’re eligible";
+        public const string FundingOption_Bursary = "Bursary or student finance if you’re eligible";
+        public const string FundingOption_StudentFinance = "Student finance if you’re eligible";
+
         private static Regex websiteRegex = new Regex("^https?:\\/\\/");
 
         public static string FormattedWebsite(this Course course)
@@ -115,19 +120,19 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters
         {
             if (course.Route.IsSalaried)
             {
-                return "Salary";
+                return FundingOption_Salary;
             }
             else if (course.HasScholarshipAndBursary())
             {
-                return "Scholarship, bursary or student finance if you’re eligible";
+                return FundingOption_Scholarship;
             }
             else if (course.HasBursary())
             {
-                return "Bursary or student finance if you’re eligible";
+                return FundingOption_Bursary;
             }
             else
             {
-                return "Student finance if you’re eligible";
+                return FundingOption_StudentFinance;
             }
         }
 

--- a/tests/Unit.Tests/ViewFormatters/CourseBuilder.cs
+++ b/tests/Unit.Tests/ViewFormatters/CourseBuilder.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.ViewFormatters
+{
+    static class CourseBuilder
+    {
+        public static Course BuildCourse(string name)
+        {
+            return new Course
+            {
+                Name = name,
+                CourseSubjects = new List<CourseSubject>(),
+                Route = new Route(),
+            };
+
+        }
+
+        public static Course AddBursaryAndScholarshipSubject(this Course course)
+        {
+            course.CourseSubjects.Add(new CourseSubject {Subject = new Subject {Funding = new SubjectFunding {BursaryFirst = 123, Scholarship = 666}}});
+            return course;
+        }
+
+        public static Course AddBursarySubject(this Course course)
+        {
+            course.CourseSubjects.Add(new CourseSubject {Subject = new Subject {Funding = new SubjectFunding {BursaryFirst = 777}}});
+            return course;
+        }
+
+        public static Course AddSalary(this Course course)
+        {
+            course.Route.IsSalaried = true;
+            return course;
+        }
+    }
+}

--- a/tests/Unit.Tests/ViewFormatters/CourseBuilder.cs
+++ b/tests/Unit.Tests/ViewFormatters/CourseBuilder.cs
@@ -17,15 +17,21 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.ViewFormatters
 
         }
 
-        public static Course AddBursaryAndScholarshipSubject(this Course course)
+        public static Course AddSubject(this Course course)
         {
-            course.CourseSubjects.Add(new CourseSubject {Subject = new Subject {Funding = new SubjectFunding {BursaryFirst = 123, Scholarship = 666}}});
+            course.CourseSubjects.Add(new CourseSubject {Subject = new Subject()});
             return course;
         }
 
         public static Course AddBursarySubject(this Course course)
         {
             course.CourseSubjects.Add(new CourseSubject {Subject = new Subject {Funding = new SubjectFunding {BursaryFirst = 777}}});
+            return course;
+        }
+
+        public static Course AddBursaryAndScholarshipSubject(this Course course)
+        {
+            course.CourseSubjects.Add(new CourseSubject {Subject = new Subject {Funding = new SubjectFunding {BursaryFirst = 123, Scholarship = 666}}});
             return course;
         }
 

--- a/tests/Unit.Tests/ViewFormatters/CourseExtensions.Tests.cs
+++ b/tests/Unit.Tests/ViewFormatters/CourseExtensions.Tests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
 using GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters;
@@ -139,6 +140,60 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewFormatters
             var course = CourseBuilder.BuildCourse("Salary")
                 .AddSalary();
             course.FundingOptions().Should().Be(CourseExtensions.FundingOption_Salary);
+        }
+
+        // the 17 courses in prod that have funding in their secondary subject in the db but don't actually get funding
+        [Test]
+        [TestCase("Drama (with English)")]
+        [TestCase("Drama (with English)")]
+        [TestCase("Media Studies (with English)")]
+        [TestCase("PE with Maths")]
+        [TestCase("Physical Education (with EBacc Subject)")]
+        [TestCase("Physical Education (with English 11-16)")]
+        [TestCase("Physical Education (with Geography 11-16)")]
+        [TestCase("Physical Education (with Mathematics 11-16)")]
+        [TestCase("Physical Education with Biology")]
+        [TestCase("Physical Education with Chemistry")]
+        [TestCase("Physical Education with Computer Science")]
+        [TestCase("Physical Education with English")]
+        [TestCase("Physical Education with French")]
+        [TestCase("Physical Education with Geography")]
+        [TestCase("Physical Education with History")]
+        [TestCase("Physical Education with Mathematics")]
+        [TestCase("Physical Education with Maths specialism")]
+        [TestCase("Physical Education with Physics")]
+        [TestCase("Physical Education with Spanish")]
+        public void OverriddenFunding(string courseName)
+        {
+            using (new AssertionScope())
+            {
+                var course1 = CourseBuilder.BuildCourse(courseName)
+                    .AddBursarySubject()
+                    .AddBursaryAndScholarshipSubject();
+                course1.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+                var course2 = CourseBuilder.BuildCourse(courseName)
+                    .AddSubject()
+                    .AddBursaryAndScholarshipSubject();
+                course2.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+                var course3 = CourseBuilder.BuildCourse(courseName)
+                    .AddSubject()
+                    .AddBursarySubject();
+                course3.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+                var course4 = CourseBuilder.BuildCourse(courseName)
+                    .AddSubject();
+                course4.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+                var course5 = CourseBuilder.BuildCourse(courseName)
+                    .AddSubject()
+                    .AddSubject();
+                course5.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+
+                var course6 = CourseBuilder.BuildCourse(courseName)
+                    .AddBursarySubject();
+                course6.FundingOptions().Should().Be(CourseExtensions.FundingOption_Bursary);
+                var course7 = CourseBuilder.BuildCourse(courseName)
+                    .AddBursaryAndScholarshipSubject();
+                course7.FundingOptions().Should().Be(CourseExtensions.FundingOption_Scholarship);
+            }
         }
     }
 }

--- a/tests/Unit.Tests/ViewFormatters/CourseExtensions.Tests.cs
+++ b/tests/Unit.Tests/ViewFormatters/CourseExtensions.Tests.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
 using GovUk.Education.SearchAndCompare.UI.Shared.ViewFormatters;
 using NUnit.Framework;
+using SearchAndCompareUI.Tests.Unit.Tests.ViewFormatters;
 
 namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewFormatters
 {
@@ -59,6 +62,83 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.ViewFormatters
         {
             var formattedDistance = input.FormattedDistance();
             formattedDistance.Should().Be(expectedDisplayValue, $"for input of {input} metres");
+        }
+
+        [Test]
+        public void CourseWithoutFunding_HasScholarshipAndBursary_IsFalse()
+        {
+            var course = CourseBuilder.BuildCourse("No funding");
+            course.HasScholarshipAndBursary().Should().BeFalse("There is no funding on the course");
+        }
+
+        [Test]
+        public void CourseWithBursary_HasScholarshipAndBursary_IsFalse()
+        {
+            var course = CourseBuilder.BuildCourse("Bursary")
+                .AddBursarySubject();
+            course.HasScholarshipAndBursary().Should().BeFalse("There is only a bursary on the course");
+        }
+
+        [Test]
+        public void CourseWithBursaryAndScholarship_HasScholarshipAndBursary_IsTrue()
+        {
+            var course = CourseBuilder.BuildCourse("Scholarship")
+                .AddBursaryAndScholarshipSubject();
+            course.HasScholarshipAndBursary().Should().BeTrue("There is scholarship funding on the course");
+        }
+
+        [Test]
+        public void CourseWithoutFunding_HasBursary_IsFalse()
+        {
+            var course = CourseBuilder.BuildCourse("No funding");
+            course.HasBursary().Should().BeFalse("There is no funding on the course");
+        }
+
+        [Test]
+        public void CourseWithBursary_HasBursary_IsTrue()
+        {
+            var course = CourseBuilder.BuildCourse("Bursary")
+                .AddBursarySubject();
+            course.HasBursary().Should().BeTrue("There is funding on the course");
+        }
+
+        [Test]
+        public void CourseWithBursaryAndScholarship_HasBursary_IsTrue()
+        {
+            var course = CourseBuilder.BuildCourse("Scholarship")
+                .AddBursaryAndScholarshipSubject();
+            course.HasBursary().Should().BeTrue("There is scholarship funding on the course");
+        }
+
+        [Test]
+        public void FundingOptions_Scholarship()
+        {
+            var course = CourseBuilder.BuildCourse("Scholarship")
+                .AddBursaryAndScholarshipSubject();
+            course.FundingOptions().Should().Be(CourseExtensions.FundingOption_Scholarship);
+        }
+
+        [Test]
+        public void FundingOptions_Bursary()
+        {
+            var course = CourseBuilder.BuildCourse("Bursary")
+                .AddBursarySubject();
+            course.FundingOptions().Should().Be(CourseExtensions.FundingOption_Bursary);
+        }
+
+        [Test]
+        public void FundingOptions_StudentFinance()
+        {
+            var course = CourseBuilder.BuildCourse("StudentFinance");
+            course.FundingOptions().Should().Be(CourseExtensions.FundingOption_StudentFinance);
+        }
+
+        [Test]
+        public void FundingOptions_Salary()
+        {
+            var course = CourseBuilder.BuildCourse("Salary")
+                .AddSalary();
+            course.FundingOptions().Should().Be(CourseExtensions.FundingOption_Salary);
         }
     }
 }


### PR DESCRIPTION
# Context

"SubjectX with SubjectY" where SubjectX isn't funded and SubjectY is funded is incorrectly showing funding information. It matters that it is "X with Y" (Y is a second subject) rather than "X and Y" (both subjects are equal).

This is a bit of a hack in the frontend because the proper fix would require changing the data model in both "publish" and "find", i.e. api+ui x2 plus nuget package. The whole model is changing once we become the owners of the data so it's not worth re-modelling this now. Also there's the c# to rails change going on.

# Changes

Spot the problematic style of course for specific unfunded courses and override the funding display.

# Testing

## Before

https://find-postgraduate-teacher-training.education.gov.uk/course/W75/3CZ8#section-financial-support

> University of Wolverhampton
> Physical Education with Computer Science (3CZ8) 

![image](https://user-images.githubusercontent.com/19378/54747452-e4752100-4bc6-11e9-9b98-c860ba50c9bc.png)

![image](https://user-images.githubusercontent.com/19378/54749179-b514e300-4bcb-11e9-80e5-8bbffd23714c.png)

https://find-postgraduate-teacher-training.education.gov.uk/results?l=3&subjects=29&query=University%20of%20Wolverhampton&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False

![image](https://user-images.githubusercontent.com/19378/54749341-2785c300-4bcc-11e9-8e9b-00584957231e.png)


## After

![image](https://user-images.githubusercontent.com/19378/54749097-73843800-4bcb-11e9-80b8-e1c5bcee87de.png)

![image](https://user-images.githubusercontent.com/19378/54749233-d7a6fc00-4bcb-11e9-8abc-e514369b75dd.png)

http://localhost:5000/results?l=3&subjects=29&query=University%20of%20Wolverhampton&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False

![image](https://user-images.githubusercontent.com/19378/54749390-4ab07280-4bcc-11e9-8354-e1def380d0a1.png)

## SQL

This is the equivalent of the new logic and matches the 17 problematic rows

    select c."Name", s."Name", s."FundingId" from course c
    inner join course_subject cs on cs."CourseId" = c."Id"
    inner join subject s on s."Id" = cs."SubjectId"
    where s."FundingId" is not null
    and (c."Name" like 'PE%' or c."Name" like 'Physical Education%' or c."Name" like 'Drama%'
         or c."Name" like 'Media Studies%')
    and c."Name" like '%with%';