### PR TITLE
[1296] Make map more resilient to missing lat/lng

### DIFF
--- a/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
+++ b/shared/Views/Shared/Components/CourseDetails/_Apply.cshtml
@@ -88,8 +88,8 @@
         {
           "code": "@campus.CampusCode",
           "name": "@campus.Name",
-          "lat": @(campus.Location == null ? Model.Course.ProviderLocation.Latitude : campus.Location.Latitude),
-          "lng": @(campus.Location == null ? Model.Course.ProviderLocation.Longitude : campus.Location.Longitude),
+          "lat": "@(campus.Location == null ? Model.Course.ProviderLocation.Latitude : campus.Location.Latitude)",
+          "lng": "@(campus.Location == null ? Model.Course.ProviderLocation.Longitude : campus.Location.Longitude)",
           "address": "@campus.Location?.Address",
           "vacancies": "@(string.IsNullOrWhiteSpace(campus.VacStatus) ? "No vacancies" : "")"
         },

--- a/src/Assets/Javascript/locations-map.js
+++ b/src/Assets/Javascript/locations-map.js
@@ -1,13 +1,28 @@
 import createPopupClass from "./map-popup";
 
 const initLocationsMap = () => {
+  const $map = document.getElementById("locations-map");
+  const trainingLocations = window.trainingLocations
+    .filter(({lat, lng}) => lat !== "" && lng !== "")
+    .map(location => {
+      location.lat = parseFloat(location.lat);
+      location.lng = parseFloat(location.lng);
+      return location;
+    })
+
+  if (trainingLocations.length === 0) {
+    console.error("Failed to initialise map: center is impossible to display, because none of the locations have a lat/lng.");
+    $map.style.display = 'none';
+    return;
+  }
+
   const Popup = createPopupClass();
   const bounds = new google.maps.LatLngBounds();
 
-  const centerLat = window.trainingLocations[0].lat;
-  const centerLng = window.trainingLocations[0].lng;
+  const centerLat = trainingLocations[0].lat;
+  const centerLng = trainingLocations[0].lng;
 
-  const map = new google.maps.Map(document.getElementById("locations-map"), {
+  const map = new google.maps.Map($map, {
     mapTypeId: google.maps.MapTypeId.ROADMAP,
     mapTypeControl: false,
     scaleControl: false,


### PR DESCRIPTION
### Context

If the postcode is incorrect, the lat/lng will end up being null, which will cause the frontend JS to blow up.

### Changes proposed in this pull request

- Pass in lat/lng as a string to the frontend, parseFloat it in JS
- If none of the locations have a non-`""` lat/lng, then we can't show
  a useful map, so hide it and log an error

### Guidance to review

No tests. :/