### PR TITLE
Delete link to aboutcookies.org

### DIFF
--- a/src/Views/Legal/Cookies.cshtml
+++ b/src/Views/Legal/Cookies.cshtml
@@ -16,7 +16,6 @@
         </ul>
 
         <p class="govuk-body">‘Find postgraduate teacher training’ cookies aren’t used to identify you personally.</p>
-        <p class="govuk-body">Find out more about <a href="http://www.aboutcookies.org/" rel="external" class="govuk-link">how to manage cookies</a>.</p>
 
         <h2 class="govuk-heading-l">How we use cookies</h2>
 


### PR DESCRIPTION
It's not clear why we added this link in April 2018. Information on this website appears out of date, does not cover GDPR and relates to 2011 cookie laws.

GOV.UK does not explain how to manage cookies.