### PR TITLE
[2741] Redirect course page to new app

### DIFF
--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.SearchAndCompare.Domain.Client;
 using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;
@@ -10,33 +11,18 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
     public class CourseController : Controller
     {
         private readonly ISearchAndCompareApi _api;
+        private readonly IRedirectUrlService redirectUrlService;
 
-        public CourseController(ISearchAndCompareApi api)
+        public CourseController(ISearchAndCompareApi api, IRedirectUrlService redirectUrlService)
         {
             _api = api;
+            this.redirectUrlService = redirectUrlService;
         }
 
         [HttpGet("course/{providerCode}/{courseCode}", Name = "Course")]
         public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter)
         {
-            var course = _api.GetCourse(providerCode, courseCode);
-            var feeCaps = _api.GetFeeCaps();
-
-            var latestFeeCaps = feeCaps.OrderByDescending(x => x.EndYear).FirstOrDefault();
-
-            if (course == null || latestFeeCaps == null)
-            {
-                return NotFound();
-            }
-
-            var viewModel = new CourseDetailsViewModel()
-            {
-                Course = course,
-                Finance = new Shared.ViewModels.FinanceViewModel(course, latestFeeCaps),
-                PreviewMode = false
-            };
-
-            return View(viewModel);
+            return redirectUrlService.RedirectToNewApp("/course/" + $"{providerCode}" + "/" + $"{courseCode}");
         }
     }
 }

--- a/src/SearchUiConfig.cs
+++ b/src/SearchUiConfig.cs
@@ -6,6 +6,7 @@ namespace GovUk.Education.SearchAndCompare.UI
     public class SearchUiConfig
     {
         private const string ConfigKeyApiUrl = "API_URL";
+        private const string NewAppUrl = "NEW_APP_URL";
 
         private readonly IConfiguration _configuration;
 

--- a/src/Services/IRedirectUrlService.cs
+++ b/src/Services/IRedirectUrlService.cs
@@ -1,0 +1,10 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.SearchAndCompare.UI.Services
+{
+    public interface IRedirectUrlService
+    {
+        RedirectResult RedirectToNewApp(string path);
+    }
+}

--- a/src/Services/RedirectUrlService.cs
+++ b/src/Services/RedirectUrlService.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.SearchAndCompare.UI.Services
+{
+    public class RedirectUrlService : IRedirectUrlService
+    {
+        private string frontendBaseUrl;
+        private readonly IConfiguration _configuration;
+
+        public RedirectUrlService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            this.frontendBaseUrl = _configuration["NEW_APP_URL"];
+        }
+
+        public RedirectResult RedirectToNewApp(string path)
+        {
+            return new RedirectResult(frontendBaseUrl + path);
+        }
+    }
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -96,6 +96,7 @@ namespace GovUk.Education.SearchAndCompare.UI
             services.AddScoped<IFeatureFlags, FeatureFlags>();
             services.AddScoped<GoogleAnalyticsClient>(p => new GoogleAnalyticsClient(p.GetService<IHttpClient>(), magicStringForGoogleAnalytics));
             services.AddSingleton<IGeocoder>(provider => new Geocoder(Configuration["google_cloud_platform_key_geocoding"], new HttpClient()));
+            services.AddSingleton<IRedirectUrlService, RedirectUrlService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -7,5 +7,6 @@
       "Microsoft": "Information"
     }
   },
-  "API_URL": "https://api.find-postgraduate-teacher-training.service.gov.uk"
+  "API_URL": "https://api.find-postgraduate-teacher-training.service.gov.uk",
+  "NEW_APP_URL": "http://localhost:3002"
 }

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.SearchAndCompare.Domain.Client;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.UI.Controllers;
 using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Shared.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -15,34 +16,18 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
     public class CourseControllerTests
     {
         [Test]
-        public void Index_NotFound()
-        {
-            var mockApi = new Mock<ISearchAndCompareApi>();
-            mockApi.Setup(x=>x.GetFeeCaps()).Returns(new List<FeeCaps>());
-            var controller = new CourseController(mockApi.Object);
-
-            var res = controller.Index("abc", "def", new ResultsFilter());
-
-            Assert.That(res is StatusCodeResult);
-            Assert.AreEqual(404, (res as StatusCodeResult).StatusCode);
-        }
-
-        [Test]
         public void Index()
         {
+            var redirectUrlMock = new Mock<IRedirectUrlService>();
+            redirectUrlMock.Setup(x => x.RedirectToNewApp("/course/abc/def")).Returns(new RedirectResult("frontend"));
             var mockApi = new Mock<ISearchAndCompareApi>();
             mockApi.Setup(x => x.GetCourse("abc","def")).Returns( new Course {Name = "my course", Fees = new Fees {Uk = 456}}).Verifiable();
             mockApi.Setup(x => x.GetFeeCaps()).Returns(new List<FeeCaps> {new FeeCaps {UkFees = 123}}).Verifiable();
-            var controller = new CourseController(mockApi.Object);
+            var controller = new CourseController(mockApi.Object, redirectUrlMock.Object);
 
             var res = controller.Index("abc", "def", new ResultsFilter());
 
-            Assert.That(res is ViewResult);
-            Assert.That((res as ViewResult).Model is CourseDetailsViewModel);
-
-            var model = (res as ViewResult).Model as CourseDetailsViewModel;
-            Assert.AreEqual("my course", model.Course.Name);
-            Assert.AreEqual("£456", model.Finance.FormattedUkFees);
+            Assert.IsTrue(res is RedirectResult);
         }
     }
 }

--- a/tests/Unit.Tests/Services/RedirectUrlServiceTest.cs
+++ b/tests/Unit.Tests/Services/RedirectUrlServiceTest.cs
@@ -1,0 +1,26 @@
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.UI.Services;
+using NUnit.Framework;
+using FluentAssertions;
+using System;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+
+namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Services
+{
+    [TestFixture]
+    public class RedirectUrlServiceTests
+    {
+        [Test]
+        public void ReturnsRedirectResultToFrontend()
+        {
+            var configMock = new Mock<IConfiguration>();
+            configMock.SetupGet(c => c["NEW_APP_URL"]).Returns("http://new-app:123");
+
+            var searchAndCompareUrlService = new RedirectUrlService(configMock.Object);
+            searchAndCompareUrlService.RedirectToNewApp("/course/123/4567").Url.Should().Be("http://new-app:123/course/123/4567");
+        }
+    }
+}


### PR DESCRIPTION
### Context
We have a new course page rendered but our FIND app which uses our manage-courses-backend API.

### Changes proposed in this pull request
Redirect course page to rails version

### Guidance to review
Attempt to navigate to a course and you should be redirected to the rails version on port 3002
