### PR TITLE
[2772] Added redirect for study type

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -286,6 +286,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("StudyType")]
         public IActionResult StudyType(ResultsFilter model)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             return View(model);
         }
 

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -41,6 +41,8 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             {
                 funding = 2,
                 hasvacancies = true,
+                fulltime = true,
+                parttime = false,
             };
         }
 
@@ -64,6 +66,32 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
                 .Returns(redirectObject);
 
             var result = _filterController.Funding(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+
+
+        [Test]
+        public void StudyTypeHttpGetTest()
+        {
+            var result = _filterController.StudyType(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().Be(_resultsFilter);
+        }
+
+        [Test]
+        public void StudyTypeRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            string actualRedirectPath = "results/filter/studytype?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.StudyType(_resultsFilter) as RedirectResult;
             result.Should().Be(redirectObject);
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
             result.Url.Should().Be(actualRedirectPath);


### PR DESCRIPTION
### Context
Branched off from #490 
Redirect to rails

### Changes proposed in this pull request
Redirect to rails

### Guidance to review
Set these
```
FEATURE_REDIRECT_TO_RAILS
NEW_APP_URL
```
This end point 
`/results/filter/studytype` with or without query will be redirect to NEW_APP_URL +  `/results/filter/studytype`

