### PR TITLE
[2780] Redirect subject filter page to rails

### DIFF
--- a/src/.tool-versions
+++ b/src/.tool-versions
@@ -1,1 +1,2 @@
 dotnet-core 2.1.403
+nodejs 8.16.1

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,6 +43,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjectAreas = _api.GetSubjectAreas();
 
             var viewModel = new SubjectFilterViewModel

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -114,5 +114,21 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             model.FilterModel.Should().Be(_resultsFilter);
             model.SubjectAreas.Should().BeSameAs(mockSubjectAreas);
         }
+
+        [Test]
+        public void SubjectGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            const string actualRedirectPath = "results/filter/subject?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.SubjectGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
     }
 }

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -1,11 +1,14 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.Services;
 using GovUk.Education.SearchAndCompare.UI.Controllers;
 using GovUk.Education.SearchAndCompare.UI.Filters;
 using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Shared.Features;
 using GovUk.Education.SearchAndCompare.UI.Unit;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
@@ -20,16 +23,17 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         private ResultsFilter _resultsFilter;
         private Mock<IFeatureFlags> _mockFlag;
         private Mock<IRedirectUrlService> _redirectUrlMock;
+        private Mock<ISearchAndCompareApi> _mockApi;
 
         [SetUp]
         public void SetUp()
         {
-            var mockApi = new Mock<ISearchAndCompareApi>();
+            _mockApi = new Mock<ISearchAndCompareApi>();
             _mockFlag = new Mock<IFeatureFlags>();
             var mockGeocoder = new Mock<IGeocoder>();
 
             _redirectUrlMock = new Mock<IRedirectUrlService>();
-            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object,
+            _filterController = new FilterController(_mockApi.Object, mockGeocoder.Object,
                 TelemetryClientHelper.GetMocked(),
                 new GoogleAnalyticsClient(null, null),
                 _redirectUrlMock.Object,
@@ -95,6 +99,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             result.Should().Be(redirectObject);
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
             result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
+        public void SubjectGetHttpGetTest()
+        {
+            var mockSubjectAreas = new List<SubjectArea>();
+            _mockApi.Setup(api => api.GetSubjectAreas()).Returns(mockSubjectAreas);
+            var result = _filterController.SubjectGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType<SubjectFilterViewModel>();
+            var model = (SubjectFilterViewModel)viewResult?.Model;
+            model.FilterModel.Should().Be(_resultsFilter);
+            model.SubjectAreas.Should().BeSameAs(mockSubjectAreas);
         }
     }
 }


### PR DESCRIPTION
### Context

Rails is nearly ready to take over this page so prepping the redirect now.

### Changes proposed in this pull request

* Regression test existing behaviour (good practice for working with legacy code)
* TDD redirection to new page

### Guidance to review

```bash
FEATURE_REDIRECT_TO_RAILS=true dotnet run
```