### PR TITLE
[2780] Redirect subject filter page to rails

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,6 +43,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjectAreas = _api.GetSubjectAreas();
 
             var viewModel = new SubjectFilterViewModel

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -116,6 +116,22 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         }
 
         [Test]
+        public void SubjectGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            const string actualRedirectPath = "results/filter/subject?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.SubjectGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
         public void VacancyHttpGetTest()
         {
             var result = _filterController.Vacancy(_resultsFilter);


### PR DESCRIPTION
### Context

replacement for accidentally closed #496

Rails is nearly ready to take over this page so prepping the redirect now.

### Changes proposed in this pull request

* Regression test existing behaviour (good practice for working with legacy code)
* TDD redirection to new page

### Guidance to review

```bash
FEATURE_REDIRECT_TO_RAILS=true dotnet run
```