### PR TITLE
[2777] Redirect Qualifications filter to rails

### DIFF
--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -265,6 +265,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Qualification")]
         public IActionResult QualificationGet(ResultsFilter model)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             // Put the posted qualifications into a comma separated string
             model.qualifications = model.qualification.Any() ? string.Join(",", model.qualification.Select(q => Enum.GetName(typeof(QualificationOption), q))) : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
             model.qualification = new List<QualificationOption>(); // Remove this from the url

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -121,5 +121,30 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
             result.Url.Should().Be(actualRedirectPath);
         }
+
+        [Test]
+        public void QualificationGetHttpGetTest()
+        {
+            var result = _filterController.QualificationGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().Be(_resultsFilter);
+        }
+
+        [Test]
+        public void QualificationGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            string actualRedirectPath = "results/filter/qualification?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.QualificationGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
     }
 }


### PR DESCRIPTION
### Context

rails nearly ready to operate this page

### Changes proposed in this pull request

* [2777] Redirect Qualifications filter to rails

### Guidance to review

```bash
FEATURE_REDIRECT_TO_RAILS=true dotnet run
```

visit

* http://localhost:5000/results/filter/qualification?qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False