### PR TITLE
[2840] Amended to use dedicated feature flags

### DIFF
--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -9,18 +9,54 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
     {
         private readonly IConfiguration _config;
 
+        private const string FEATURE_REDIRECT_TO_RAILS = "FEATURE_REDIRECT_TO_RAILS";
+
         public FeatureFlags(IConfiguration config)
         {
             _config = config;
         }
 
         public bool Maps => ShouldShow("FEATURE_MAPS");
-        public bool RedirectToRails => ShouldShow("FEATURE_REDIRECT_TO_RAILS");
+
+        public bool RedirectToRailsPageFunding => RedirectToRailsPage("FUNDING");
+        public bool RedirectToRailsPageQualification => RedirectToRailsPage("QUALIFICATION");
+        public bool RedirectToRailsPageStudyType => RedirectToRailsPage("STUDYTYPE");
+        public bool RedirectToRailsPageVacancy => RedirectToRailsPage("VACANCY");
+        public bool RedirectToRailsPageCourse => RedirectToRailsPage("COURSE");
 
         public bool ShouldShow(string key)
         {
             var value = _config[key];
             return !string.IsNullOrWhiteSpace(value) && value.Trim().ToLower().Equals("true");
         }
+
+        /// <summary>
+        /// wizard pages
+        ///
+        /// /
+        ///                 LOCATIONWIZARD
+        /// /start/subject
+        ///                 SUBJECTWIZARD
+        ///
+        ///
+        /// filter pages
+        ///
+        /// /results/filter/
+        ///                 SUBJECT
+        ///                 LOCATION
+        ///                 FUNDING
+        ///                 QUALIFICATION
+        ///                 STUDYTYPE
+        ///                 VACANCY
+        ///                 PROVIDER
+        ///
+        /// results page
+        /// /results
+        ///                 RESULTS
+        /// course page
+        /// /course
+        ///                 COURSE
+        /// </summary>
+        private bool RedirectToRailsPage(string page) => ShouldShow($"{FEATURE_REDIRECT_TO_RAILS}_{page.ToUpperInvariant()}");
     }
 }

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -7,6 +7,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
     public interface IFeatureFlags
     {
         bool Maps { get; }
-        bool RedirectToRails { get; }
+
+        bool RedirectToRailsPageFunding { get; }
+        bool RedirectToRailsPageQualification { get; }
+        bool RedirectToRailsPageStudyType { get; }
+        bool RedirectToRailsPageVacancy { get; }
+        bool RedirectToRailsPageCourse { get; }
     }
 }

--- a/src/Controllers/CourseController.cs
+++ b/src/Controllers/CourseController.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("course/{providerCode}/{courseCode}", Name = "Course")]
         public IActionResult Index(string providerCode, string courseCode, ResultsFilter filter)
         {
-            if (featureFlags.RedirectToRails)
+            if (featureFlags.RedirectToRailsPageCourse)
             {
                 return redirectUrlService.RedirectToNewApp("/course/" + $"{providerCode}" + "/" + $"{courseCode}");
             }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,6 +43,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageSubject)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjectAreas = _api.GetSubjectAreas();
 
             var viewModel = new SubjectFilterViewModel
@@ -126,6 +131,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationGet")]
         public IActionResult LocationGet(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageLocation)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var viewModel = new LocationFilterViewModel
             {
                 FilterModel = filter
@@ -202,6 +212,10 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationWizard")]
         public IActionResult LocationWizardGet(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageLocationWizard)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
             ViewBag.IsInWizard = true;
             //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
             filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
@@ -220,7 +234,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("results/filter/funding")]
         public IActionResult Funding(ResultsFilter filter)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageFunding)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }
@@ -265,7 +279,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Qualification")]
         public IActionResult QualificationGet(ResultsFilter model)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageQualification)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }
@@ -291,7 +305,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("StudyType")]
         public IActionResult StudyType(ResultsFilter model)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageStudyType)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }
@@ -311,7 +325,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Vacancy")]
         public IActionResult Vacancy(ResultsFilter model)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageVacancy)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }
@@ -332,6 +346,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Provider")]
         public IActionResult Provider(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageProvider)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             List<Provider> suggestions = TempData.Get<List<Provider>>("Suggestions");
             if (suggestions == null)
             {

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,11 +43,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
-            if (_featureFlags.RedirectToRailsPageSubject)
-            {
-                return _redirectUrlService.RedirectToNewApp();
-            }
-
             var subjectAreas = _api.GetSubjectAreas();
 
             var viewModel = new SubjectFilterViewModel
@@ -131,11 +126,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationGet")]
         public IActionResult LocationGet(ResultsFilter filter)
         {
-            if (_featureFlags.RedirectToRailsPageLocation)
-            {
-                return _redirectUrlService.RedirectToNewApp();
-            }
-
             var viewModel = new LocationFilterViewModel
             {
                 FilterModel = filter
@@ -212,10 +202,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationWizard")]
         public IActionResult LocationWizardGet(ResultsFilter filter)
         {
-            if (_featureFlags.RedirectToRailsPageLocationWizard)
-            {
-                return _redirectUrlService.RedirectToNewApp();
-            }
             ViewBag.IsInWizard = true;
             //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
             filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));
@@ -346,11 +332,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Provider")]
         public IActionResult Provider(ResultsFilter filter)
         {
-            if (_featureFlags.RedirectToRailsPageProvider)
-            {
-                return _redirectUrlService.RedirectToNewApp();
-            }
-
             List<Provider> suggestions = TempData.Get<List<Provider>>("Suggestions");
             if (suggestions == null)
             {

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -55,11 +55,6 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("results")]
         public IActionResult Index(ResultsFilter filter)
         {
-            if (_featureFlags.RedirectToRailsPageResults)
-            {
-                return _redirectUrlService.RedirectToNewApp();
-            }
-
             var subjects = _api.GetSubjects();
             if (subjects == null)
             {

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -6,6 +6,7 @@ using GovUk.Education.SearchAndCompare.Domain.Filters.Enums;
 using GovUk.Education.SearchAndCompare.Domain.Lists;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Services.Maps;
 using GovUk.Education.SearchAndCompare.UI.Services.Maps.Models;
 using GovUk.Education.SearchAndCompare.UI.Shared.Features;
@@ -20,11 +21,16 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
     {
         private readonly ISearchAndCompareApi _api;
         private readonly IFeatureFlags _featureFlags;
+        private readonly IRedirectUrlService _redirectUrlService;
 
-        public ResultsController(ISearchAndCompareApi api, IFeatureFlags featureFlags)
+        public ResultsController(
+            ISearchAndCompareApi api,
+            IFeatureFlags featureFlags,
+            IRedirectUrlService redirectUrlService)
         {
             _api = api;
             _featureFlags = featureFlags;
+            _redirectUrlService = redirectUrlService;
         }
 
         [HttpPost("results/map")]
@@ -49,6 +55,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("results")]
         public IActionResult Index(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageResults)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjects = _api.GetSubjects();
             if (subjects == null)
             {

--- a/tests/Unit.Tests/Controllers/CourseController.Tests.cs
+++ b/tests/Unit.Tests/Controllers/CourseController.Tests.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Unit.Tests.Controllers
             mockApi.Setup(x => x.GetFeeCaps()).Returns(new List<FeeCaps> {new FeeCaps {UkFees = 123}}).Verifiable();
 
             var mockFlag = new Mock<IFeatureFlags>();
-            mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            mockFlag.Setup(x => x.RedirectToRailsPageCourse).Returns(true);
             var controller = new CourseController(mockApi.Object, redirectUrlMock.Object, mockFlag.Object);
 
             var res = controller.Index("abc", "def", new ResultsFilter());

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -58,7 +58,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void FundingRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageFunding).Returns(true);
             string actualRedirectPath = "results/filter/funding?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);
@@ -70,7 +70,6 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
             result.Url.Should().Be(actualRedirectPath);
         }
-
 
         [Test]
         public void StudyTypeHttpGetTest()
@@ -84,7 +83,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void StudyTypeRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageStudyType).Returns(true);
             string actualRedirectPath = "results/filter/studytype?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);
@@ -109,7 +108,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void VacancyRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageVacancy).Returns(true);
             string actualRedirectPath = "results/filter/vacancy?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);
@@ -134,7 +133,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void QualificationGetRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageQualification).Returns(true);
             string actualRedirectPath = "results/filter/qualification?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -26,5 +26,87 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
             var featureFlags = new FeatureFlags(config.Object);
             featureFlags.ShouldShow(key).Should().Be(expected);
         }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageFunding(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Funding", configValue, expected);
+            featureFlag.RedirectToRailsPageFunding.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageQualification(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Qualification", configValue, expected);
+            featureFlag.RedirectToRailsPageQualification.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageStudyType(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("StudyType", configValue, expected);
+            featureFlag.RedirectToRailsPageStudyType.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageVacancy(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Vacancy", configValue, expected);
+            featureFlag.RedirectToRailsPageVacancy.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageCourse(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Course", configValue, expected);
+            featureFlag.RedirectToRailsPageCourse.Should().Be(expected);
+        }
+
+        private IFeatureFlags GetFeatureFlags(string suffixKey, string configValue, bool expected)
+        {
+            var config = new Mock<IConfiguration>();
+            const string prefixKey = "FEATURE_REDIRECT_TO_RAILS";
+            var key = $"{prefixKey}_{suffixKey}".ToUpperInvariant();
+            config.Setup(c => c[key]).Returns(configValue);
+            var featureFlags = new FeatureFlags(config.Object);
+            featureFlags.ShouldShow(key).Should().Be(expected);
+
+            return featureFlags;
+        }
     }
 }


### PR DESCRIPTION
### Context
Added dedicated feature flags

### Changes proposed in this pull request

`FEATURE_REDIRECT_TO_RAILS` this do not exist any more

Available flags:
`FEATURE_REDIRECT_TO_RAILS_COURSE`
`FEATURE_REDIRECT_TO_RAILS_FUNDING`
`FEATURE_REDIRECT_TO_RAILS_QUALIFICATION`
`FEATURE_REDIRECT_TO_RAILS_STUDYTYPE`
`FEATURE_REDIRECT_TO_RAILS_VACANCY`


### Guidance to review
Previously `FEATURE_REDIRECT_TO_RAILS` aka `RedirectToRails` was used as the single boolean to denote that the following is redirected, now it uses a dedicated flag per page/endpoint:

- funding filter page
- qualification filter page
- study type filter page
- vacancy filter page
- corpse details page


