### PR TITLE
2945 Redirect from c# to rails using dedicated feature flags part 1

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -142,6 +142,13 @@
             "metadata": {
                 "description": "Location feature flag to redirect to rails FIND"
             }
+        },
+        "featureRedirectToRailsSubject": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Subject feature flag to redirect to rails FIND"
+            }
         }
     },
     "variables": {
@@ -320,6 +327,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_LOCATION",
                                 "value": "[parameters('featureRedirectToRailsLocation')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_SUBJECT",
+                                "value": "[parameters('featureRedirectToRailsSubject')]"
                             }
                         ]
                     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -135,6 +135,13 @@
             "metadata": {
                 "description": "Subject Wizard feature flag to redirect to rails FIND"
             }
+        },
+        "featureRedirectToRailsLocation": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Location feature flag to redirect to rails FIND"
+            }
         }
     },
     "variables": {
@@ -309,6 +316,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_SUBJECTWIZARD",
                                 "value": "[parameters('featureRedirectToRailsSubjectWizard')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_LOCATION",
+                                "value": "[parameters('featureRedirectToRailsLocation')]"
                             }
                         ]
                     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -128,7 +128,14 @@
             "metadata": {
                 "description": "Vacancy feature flag to redirect to rails FIND"
             }
-        }        
+        },
+        "featureRedirectToRailsSubjectWizard": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Subject Wizard feature flag to redirect to rails FIND"
+            }
+        }
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
@@ -298,6 +305,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_VACANCY",
                                 "value": "[parameters('featureRedirectToRailsVacancy')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_SUBJECTWIZARD",
+                                "value": "[parameters('featureRedirectToRailsSubjectWizard')]"
                             }
                         ]
                     },

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -20,6 +20,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
 
 
         public bool RedirectToRailsPageSubjectWizard => RedirectToRailsPage("SUBJECTWIZARD");
+        public bool RedirectToRailsPageSubject => RedirectToRailsPage("SUBJECT");
         public bool RedirectToRailsPageLocation => RedirectToRailsPage("LOCATION");
         public bool RedirectToRailsPageFunding => RedirectToRailsPage("FUNDING");
         public bool RedirectToRailsPageQualification => RedirectToRailsPage("QUALIFICATION");

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -18,6 +18,8 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
 
         public bool Maps => ShouldShow("FEATURE_MAPS");
 
+
+        public bool RedirectToRailsPageSubjectWizard => RedirectToRailsPage("SUBJECTWIZARD");
         public bool RedirectToRailsPageFunding => RedirectToRailsPage("FUNDING");
         public bool RedirectToRailsPageQualification => RedirectToRailsPage("QUALIFICATION");
         public bool RedirectToRailsPageStudyType => RedirectToRailsPage("STUDYTYPE");

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -20,6 +20,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
 
 
         public bool RedirectToRailsPageSubjectWizard => RedirectToRailsPage("SUBJECTWIZARD");
+        public bool RedirectToRailsPageLocation => RedirectToRailsPage("LOCATION");
         public bool RedirectToRailsPageFunding => RedirectToRailsPage("FUNDING");
         public bool RedirectToRailsPageQualification => RedirectToRailsPage("QUALIFICATION");
         public bool RedirectToRailsPageStudyType => RedirectToRailsPage("STUDYTYPE");

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         bool Maps { get; }
 
         bool RedirectToRailsPageSubjectWizard { get; }
+        bool RedirectToRailsPageLocation { get; }
         bool RedirectToRailsPageFunding { get; }
         bool RedirectToRailsPageQualification { get; }
         bool RedirectToRailsPageStudyType { get; }

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
     {
         bool Maps { get; }
 
+        bool RedirectToRailsPageSubjectWizard { get; }
         bool RedirectToRailsPageFunding { get; }
         bool RedirectToRailsPageQualification { get; }
         bool RedirectToRailsPageStudyType { get; }

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         bool Maps { get; }
 
         bool RedirectToRailsPageSubjectWizard { get; }
+        bool RedirectToRailsPageSubject { get; }
         bool RedirectToRailsPageLocation { get; }
         bool RedirectToRailsPageFunding { get; }
         bool RedirectToRailsPageQualification { get; }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -76,7 +76,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("SubjectWizard")]
         public IActionResult SubjectWizardGet(ResultsFilter filter)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageSubjectWizard)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -76,6 +76,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("SubjectWizard")]
         public IActionResult SubjectWizardGet(ResultsFilter filter)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             ViewBag.IsInWizard = true;
             return SubjectGet(filter);
         }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -131,6 +131,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationGet")]
         public IActionResult LocationGet(ResultsFilter filter)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var viewModel = new LocationFilterViewModel
             {
                 FilterModel = filter

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -131,7 +131,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationGet")]
         public IActionResult LocationGet(ResultsFilter filter)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageLocation)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,6 +43,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
+            if (_featureFlags?.RedirectToRails == true)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjectAreas = _api.GetSubjectAreas();
 
             var viewModel = new SubjectFilterViewModel

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -43,7 +43,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Subject")]
         public IActionResult SubjectGet(ResultsFilter filter)
         {
-            if (_featureFlags?.RedirectToRails == true)
+            if (_featureFlags.RedirectToRailsPageSubject)
             {
                 return _redirectUrlService.RedirectToNewApp();
             }

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -162,7 +162,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void SubjectWizardGetRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageSubjectWizard).Returns(true);
             string actualRedirectPath = "start/subject?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Models;
 using GovUk.Education.SearchAndCompare.Services;
 using GovUk.Education.SearchAndCompare.UI.Controllers;
 using GovUk.Education.SearchAndCompare.UI.Filters;
@@ -22,6 +24,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         private Mock<IFeatureFlags> _mockFlag;
         private Mock<ISearchAndCompareApi> _mockApi;
         private Mock<IRedirectUrlService> _redirectUrlMock;
+        private Mock<ISearchAndCompareApi> _mockApi;
 
         [SetUp]
         public void SetUp()
@@ -96,6 +99,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             result.Should().Be(redirectObject);
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
             result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
+        public void SubjectGetHttpGetTest()
+        {
+            var mockSubjectAreas = new List<SubjectArea>();
+            _mockApi.Setup(api => api.GetSubjectAreas()).Returns(mockSubjectAreas);
+            var result = _filterController.SubjectGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType<SubjectFilterViewModel>();
+            var model = (SubjectFilterViewModel)viewResult?.Model;
+            model.FilterModel.Should().Be(_resultsFilter);
+            model.SubjectAreas.Should().BeSameAs(mockSubjectAreas);
         }
 
         [Test]

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -117,7 +117,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void SubjectGetRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageSubject).Returns(true);
             const string actualRedirectPath = "results/filter/subject?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -124,6 +124,33 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         }
 
         [Test]
+        public void LocationGetHttpGetTest()
+        {
+            var result = _filterController.LocationGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType<LocationFilterViewModel>();
+            var viewModel = (LocationFilterViewModel) viewResult.Model;
+            viewModel.FilterModel.Should().Be(_resultsFilter);
+        }
+
+        [Test]
+        public void LocationGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            string actualRedirectPath = "results/filter/location?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.LocationGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
         public void QualificationGetHttpGetTest()
         {
             var result = _filterController.QualificationGet(_resultsFilter);

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -137,7 +137,7 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         [Test]
         public void LocationGetRedirectsToNewApp()
         {
-            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            _mockFlag.Setup(x => x.RedirectToRailsPageLocation).Returns(true);
             string actualRedirectPath = "results/filter/location?query";
 
             var redirectObject = new RedirectResult(actualRedirectPath);

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -24,7 +24,6 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         private Mock<IFeatureFlags> _mockFlag;
         private Mock<ISearchAndCompareApi> _mockApi;
         private Mock<IRedirectUrlService> _redirectUrlMock;
-        private Mock<ISearchAndCompareApi> _mockApi;
 
         [SetUp]
         public void SetUp()

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.SearchAndCompare.UI.Filters;
 using GovUk.Education.SearchAndCompare.UI.Services;
 using GovUk.Education.SearchAndCompare.UI.Shared.Features;
 using GovUk.Education.SearchAndCompare.UI.Unit;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
@@ -19,17 +20,18 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         private FilterController _filterController;
         private ResultsFilter _resultsFilter;
         private Mock<IFeatureFlags> _mockFlag;
+        private Mock<ISearchAndCompareApi> _mockApi;
         private Mock<IRedirectUrlService> _redirectUrlMock;
 
         [SetUp]
         public void SetUp()
         {
-            var mockApi = new Mock<ISearchAndCompareApi>();
+            _mockApi = new Mock<ISearchAndCompareApi>();
             _mockFlag = new Mock<IFeatureFlags>();
             var mockGeocoder = new Mock<IGeocoder>();
 
             _redirectUrlMock = new Mock<IRedirectUrlService>();
-            _filterController = new FilterController(mockApi.Object, mockGeocoder.Object,
+            _filterController = new FilterController(_mockApi.Object, mockGeocoder.Object,
                 TelemetryClientHelper.GetMocked(),
                 new GoogleAnalyticsClient(null, null),
                 _redirectUrlMock.Object,
@@ -143,6 +145,33 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             var result = _filterController.QualificationGet(_resultsFilter) as RedirectResult;
             result.Should().Be(redirectObject);
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
+        public void SubjectWizardGetHttpGetTest()
+        {
+            var result = _filterController.SubjectWizardGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType(typeof(SubjectFilterViewModel));
+            _mockApi.Verify(x => x.GetSubjectAreas(), Times.Exactly(1));
+            viewResult.ViewData["IsInWizard"].Should().Be(true);
+        }
+
+        [Test]
+        public void SubjectWizardGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            string actualRedirectPath = "start/subject?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.SubjectWizardGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.Exactly(1));
             result.Url.Should().Be(actualRedirectPath);
         }
     }

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -115,6 +115,22 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
         }
 
         [Test]
+        public void SubjectGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRails).Returns(true);
+            const string actualRedirectPath = "results/filter/subject?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.SubjectGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+
+        [Test]
         public void VacancyHttpGetTest()
         {
             var result = _filterController.Vacancy(_resultsFilter);

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -49,6 +49,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
         [TestCase("False", false)]
         [TestCase("true", true)]
         [TestCase("True", true)]
+        public void RedirectToRailsPageLocation(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Location", configValue, expected);
+            featureFlag.RedirectToRailsPageLocation.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
         public void RedirectToRailsPageFunding(string configValue, bool expected)
         {
             var featureFlag = GetFeatureFlags("Funding", configValue, expected);

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -40,6 +40,19 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
             var featureFlag = GetFeatureFlags("SubjectWizard", configValue, expected);
             featureFlag.RedirectToRailsPageSubjectWizard.Should().Be(expected);
         }
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        public void RedirectToRailsPageSubject(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Subject", configValue, expected);
+            featureFlag.RedirectToRailsPageSubject.Should().Be(expected);
+        }
 
         [TestCase(null, false)]
         [TestCase("", false)] // this one took down prod

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -35,6 +35,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
         [TestCase("False", false)]
         [TestCase("true", true)]
         [TestCase("True", true)]
+        public void RedirectToRailsPageSubjectWizard(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("SubjectWizard", configValue, expected);
+            featureFlag.RedirectToRailsPageSubjectWizard.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
         public void RedirectToRailsPageFunding(string configValue, bool expected)
         {
             var featureFlag = GetFeatureFlags("Funding", configValue, expected);


### PR DESCRIPTION
### Context
Redirects to rails


### Changes proposed in this pull request
Added redirect for:
-  the subject wizard page (ported from #504 )
-  location filter page (ported from #501 )
-  subject filter page (ported from #498 )


### Guidance to review
Master (#507) has moved on since the original PR was raised, this PR is to close off the loop and consolidate the 3 PRs into one, along with the necessary azure changes for the new env var.

First 3 commits relates to subject wizard, then next 3 commits relates to location filter and the final set of 5 commits relates to 5.

Workflow, 
Port the original commit 1 by 1 then fix it then add azure configuration settings.

Set these

```
FEATURE_REDIRECT_TO_RAILS_SUBJECTWIZARD
FEATURE_REDIRECT_TO_RAILS_LOCATION
FEATURE_REDIRECT_TO_RAILS_SUBJECT
```

They relate to these endpoints
```
`/start/subject`
`/results/filter/location`
`/results/filter/subject`
```