### PR TITLE
2945 Redirect from c# to rails using dedicated feature flags part 2

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -149,6 +149,13 @@
             "metadata": {
                 "description": "Subject feature flag to redirect to rails FIND"
             }
+        },
+        "featureRedirectToRailsLocationWizard": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Location wizard feature flag to redirect to rails FIND"
+            }
         }
     },
     "variables": {
@@ -331,6 +338,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_SUBJECT",
                                 "value": "[parameters('featureRedirectToRailsSubject')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_LOCATIONWIZARD",
+                                "value": "[parameters('featureRedirectToRailsLocationWizard')]"
                             }
                         ]
                     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -163,6 +163,13 @@
             "metadata": {
                 "description": "Provider feature flag to redirect to rails FIND"
             }
+        },
+        "featureRedirectToRailsResults": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Results feature flag to redirect to rails FIND"
+            }
         }
     },
     "variables": {
@@ -353,6 +360,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_PROVIDER",
                                 "value": "[parameters('featureRedirectToRailsProvider')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_RESULTS",
+                                "value": "[parameters('featureRedirectToRailsResults')]"
                             }
                         ]
                     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -156,6 +156,13 @@
             "metadata": {
                 "description": "Location wizard feature flag to redirect to rails FIND"
             }
+        },
+        "featureRedirectToRailsProvider": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Provider feature flag to redirect to rails FIND"
+            }
         }
     },
     "variables": {
@@ -342,6 +349,10 @@
                             {
                                 "name": "FEATURE_REDIRECT_TO_RAILS_LOCATIONWIZARD",
                                 "value": "[parameters('featureRedirectToRailsLocationWizard')]"
+                            },
+                            {
+                                "name": "FEATURE_REDIRECT_TO_RAILS_PROVIDER",
+                                "value": "[parameters('featureRedirectToRailsProvider')]"
                             }
                         ]
                     },

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         public bool RedirectToRailsPageStudyType => RedirectToRailsPage("STUDYTYPE");
         public bool RedirectToRailsPageVacancy => RedirectToRailsPage("VACANCY");
         public bool RedirectToRailsPageProvider => RedirectToRailsPage("PROVIDER");
+        public bool RedirectToRailsPageResults => RedirectToRailsPage("RESULTS");
         public bool RedirectToRailsPageCourse => RedirectToRailsPage("COURSE");
 
         public bool ShouldShow(string key)

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
 
         public bool Maps => ShouldShow("FEATURE_MAPS");
 
-
+        public bool RedirectToRailsPageLocationWizard => RedirectToRailsPage("LOCATIONWIZARD");
         public bool RedirectToRailsPageSubjectWizard => RedirectToRailsPage("SUBJECTWIZARD");
         public bool RedirectToRailsPageSubject => RedirectToRailsPage("SUBJECT");
         public bool RedirectToRailsPageLocation => RedirectToRailsPage("LOCATION");

--- a/shared/Features/FeatureFlags.cs
+++ b/shared/Features/FeatureFlags.cs
@@ -26,6 +26,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         public bool RedirectToRailsPageQualification => RedirectToRailsPage("QUALIFICATION");
         public bool RedirectToRailsPageStudyType => RedirectToRailsPage("STUDYTYPE");
         public bool RedirectToRailsPageVacancy => RedirectToRailsPage("VACANCY");
+        public bool RedirectToRailsPageProvider => RedirectToRailsPage("PROVIDER");
         public bool RedirectToRailsPageCourse => RedirectToRailsPage("COURSE");
 
         public bool ShouldShow(string key)

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -17,6 +17,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         bool RedirectToRailsPageStudyType { get; }
         bool RedirectToRailsPageVacancy { get; }
         bool RedirectToRailsPageProvider { get; }
+        bool RedirectToRailsPageResults { get; }
         bool RedirectToRailsPageCourse { get; }
     }
 }

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -16,6 +16,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
         bool RedirectToRailsPageQualification { get; }
         bool RedirectToRailsPageStudyType { get; }
         bool RedirectToRailsPageVacancy { get; }
+        bool RedirectToRailsPageProvider { get; }
         bool RedirectToRailsPageCourse { get; }
     }
 }

--- a/shared/Features/IFeatureFlags.cs
+++ b/shared/Features/IFeatureFlags.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.SearchAndCompare.UI.Shared.Features
     {
         bool Maps { get; }
 
+        bool RedirectToRailsPageLocationWizard { get; }
         bool RedirectToRailsPageSubjectWizard { get; }
         bool RedirectToRailsPageSubject { get; }
         bool RedirectToRailsPageLocation { get; }

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -217,6 +217,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("LocationWizard")]
         public IActionResult LocationWizardGet(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageLocationWizard)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             ViewBag.IsInWizard = true;
             //filter.qualification = filter.qualification.Any() ? filter.qualification : new List<QualificationOption> { QualificationOption.QtsOnly, QualificationOption.PgdePgceWithQts, QualificationOption.Other };
             filter.qualifications = !string.IsNullOrWhiteSpace(filter.qualifications) ? filter.qualifications : string.Join(",", Enum.GetNames(typeof(QualificationOption)));

--- a/src/Controllers/FilterController.cs
+++ b/src/Controllers/FilterController.cs
@@ -352,6 +352,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [ActionName("Provider")]
         public IActionResult Provider(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageProvider)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             List<Provider> suggestions = TempData.Get<List<Provider>>("Suggestions");
             if (suggestions == null)
             {

--- a/src/Controllers/ResultsController.cs
+++ b/src/Controllers/ResultsController.cs
@@ -55,6 +55,11 @@ namespace GovUk.Education.SearchAndCompare.UI.Controllers
         [HttpGet("results")]
         public IActionResult Index(ResultsFilter filter)
         {
+            if (_featureFlags.RedirectToRailsPageResults)
+            {
+                return _redirectUrlService.RedirectToNewApp();
+            }
+
             var subjects = _api.GetSubjects();
             if (subjects == null)
             {

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -259,5 +259,30 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.Exactly(1));
             result.Url.Should().Be(actualRedirectPath);
         }
+
+        [Test]
+        public void ProviderHttpGetTest()
+        {
+            var result = _filterController.Provider(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType(typeof(ResultsFilter));
+        }
+
+        [Test]
+        public void ProviderRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRailsPageProvider).Returns(true);
+            string actualRedirectPath = "results/filter/provider?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.Provider(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.Exactly(1));
+            result.Url.Should().Be(actualRedirectPath);
+        }
     }
 }

--- a/tests/Unit.Tests/Controllers/FilterControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/FilterControllerTests.cs
@@ -233,5 +233,31 @@ namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
             _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.Exactly(1));
             result.Url.Should().Be(actualRedirectPath);
         }
+
+        [Test]
+        public void LocationWizardGetHttpGetTest()
+        {
+            var result = _filterController.LocationWizardGet(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType(typeof(LocationFilterViewModel));
+            viewResult.ViewData["IsInWizard"].Should().Be(true);
+        }
+
+        [Test]
+        public void LocationWizardGetRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRailsPageLocationWizard).Returns(true);
+            string actualRedirectPath = "/?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _filterController.LocationWizardGet(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.Exactly(1));
+            result.Url.Should().Be(actualRedirectPath);
+        }
     }
 }

--- a/tests/Unit.Tests/Controllers/ResultsControllerTests.cs
+++ b/tests/Unit.Tests/Controllers/ResultsControllerTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.UI.Controllers;
+using GovUk.Education.SearchAndCompare.UI.Filters;
+using GovUk.Education.SearchAndCompare.UI.Services;
+using GovUk.Education.SearchAndCompare.UI.Shared.Features;
+using GovUk.Education.SearchAndCompare.UI.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+using NUnit.Framework;
+
+namespace SearchAndCompareUI.Tests.Unit.Tests.Controllers
+{
+    [TestFixture]
+    public class ResultsControllerTests
+    {
+        private ResultsController _resultsController;
+        private ResultsFilter _resultsFilter;
+        private Mock<IFeatureFlags> _mockFlag;
+        private Mock<ISearchAndCompareApi> _mockApi;
+        private Mock<IRedirectUrlService> _redirectUrlMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockApi = new Mock<ISearchAndCompareApi>();
+            _mockFlag = new Mock<IFeatureFlags>();
+
+            _redirectUrlMock = new Mock<IRedirectUrlService>();
+            _resultsController = new ResultsController(_mockApi.Object,
+                _mockFlag.Object,
+                _redirectUrlMock.Object)
+            {
+                TempData = new Mock<ITempDataDictionary>().Object
+            };
+            _resultsFilter = new ResultsFilter
+            {
+                funding = 2,
+                hasvacancies = true,
+                fulltime = true,
+                parttime = false,
+            };
+        }
+
+        [Test]
+        public void IndexHttpGetTest()
+        {
+            _mockApi.Setup(x => x.GetSubjects()).Returns(new List<Subject>());
+            var result = _resultsController.Index(_resultsFilter);
+            result.Should().BeOfType<ViewResult>();
+            var viewResult = result as ViewResult;
+            viewResult?.Model.Should().BeOfType<ResultsViewModel>();
+        }
+
+        [Test]
+        public void IndexRedirectsToNewApp()
+        {
+            _mockFlag.Setup(x => x.RedirectToRailsPageResults).Returns(true);
+            string actualRedirectPath = "results?query";
+
+            var redirectObject = new RedirectResult(actualRedirectPath);
+            _redirectUrlMock.Setup(x => x.RedirectToNewApp())
+                .Returns(redirectObject);
+
+            var result = _resultsController.Index(_resultsFilter) as RedirectResult;
+            result.Should().Be(redirectObject);
+            _redirectUrlMock.Verify(x => x.RedirectToNewApp(), Times.AtLeastOnce);
+            result.Url.Should().Be(actualRedirectPath);
+        }
+    }
+}

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -146,6 +146,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
         [TestCase("False", false)]
         [TestCase("true", true)]
         [TestCase("True", true)]
+        public void RedirectToRailsPageProvider(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Provider", configValue, expected);
+            featureFlag.RedirectToRailsPageProvider.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
         public void RedirectToRailsPageCourse(string configValue, bool expected)
         {
             var featureFlag = GetFeatureFlags("Course", configValue, expected);

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -35,6 +35,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
         [TestCase("False", false)]
         [TestCase("true", true)]
         [TestCase("True", true)]
+        public void RedirectToRailsPageLocationWizard(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("LocationWizard", configValue, expected);
+            featureFlag.RedirectToRailsPageLocationWizard.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
         public void RedirectToRailsPageSubjectWizard(string configValue, bool expected)
         {
             var featureFlag = GetFeatureFlags("SubjectWizard", configValue, expected);

--- a/tests/Unit.Tests/FeatureFlagsTests.cs
+++ b/tests/Unit.Tests/FeatureFlagsTests.cs
@@ -160,6 +160,20 @@ namespace SearchAndCompareUI.Tests.Unit.Tests
         [TestCase("False", false)]
         [TestCase("true", true)]
         [TestCase("True", true)]
+        public void RedirectToRailsPageResults(string configValue, bool expected)
+        {
+            var featureFlag = GetFeatureFlags("Results", configValue, expected);
+            featureFlag.RedirectToRailsPageResults.Should().Be(expected);
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)] // this one took down prod
+        [TestCase("   ", false)]
+        [TestCase(" false  ", false)]
+        [TestCase("false", false)]
+        [TestCase("False", false)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
         public void RedirectToRailsPageCourse(string configValue, bool expected)
         {
             var featureFlag = GetFeatureFlags("Course", configValue, expected);


### PR DESCRIPTION
### Context
Redirects to rails


### Changes proposed in this pull request
Added redirect for:
- location wizard
- provider filter page
- results page


### Guidance to review

Set these

```
FEATURE_REDIRECT_TO_RAILS_LOCATIONWIZARD
FEATURE_REDIRECT_TO_RAILS_PROVIDER
FEATURE_REDIRECT_TO_RAILS_RESULTS
```

They relate to these endpoints
```
`/`
`/results/filter/provider`
`/results`
```